### PR TITLE
WIP: Challenge listing refactoring

### DIFF
--- a/src/shared/actions/challenge-listing.js
+++ b/src/shared/actions/challenge-listing.js
@@ -1,13 +1,133 @@
 /**
  * Challenge listing actions.
+ *
+ * In the Redux state we keep an array of challenge objects loaded into the
+ * listing(s), and a set of UUIDs of pending requests to load more challenges.
+ * To load more challenges you should first dispatch GET_INIT action with some
+ * UUID (use shortid package to generate it), then one of GET_CHALLENGES,
+ * GET_MARATHON_MATCHES, GET_USER_CHALLENGES, or GET_USER_MARATHON_MATCHES
+ * actions with the same UUID and a set of authorization, filtering, and
+ * pagination options. Received challenges will be merged into the array of
+ * challenges stored in the state, with some filtering options appended to the
+ * challenge objects (so that we can filter them again at the frontend side:
+ * challenge objects received from the backend do not include some of the
+ * necessary data, like groupIds, lists of participating users, etc).
+ *
+ * RESET action allows to remove all loaded challenges and cancel any pending
+ * requests to load challenges (removing an UUID from the set of pending
+ * requests results in ignoring the response for that request).
+ *
+ * The backend includes into each response the total count of challenges
+ * matching the specified filtering options (the actual number of challenge
+ * objects included into the response might be smaller, due to the pagination
+ * params). If "count" argument was provided in the dispatched action,
+ * the total count of matching challenges from the response will be written
+ * into a special map of counts in the Redux state.
  */
 
-import _ from 'lodash';
+import logger from 'utils/logger';
 import { createActions } from 'redux-actions';
-// import { getService } from 'services/challenges';
+import { getService } from 'services/challenges';
+
+/**
+ * Private. Common processing of promises returned from ChallengesService.
+ * @param {Object} promise
+ * @param {String} uuid
+ * @param {Object} filters
+ * @param {Object} countCategory
+ * @param {String} user
+ * @return {Promise}
+ */
+function handle(promise, uuid, filters, countCategory, user) {
+  return promise.catch((error) => {
+    logger.error(error);
+    return {
+      challenges: [],
+      totalCount: 0,
+    };
+  }).then(res => ({
+    challenges: res.challenges,
+    filters,
+    totalCount: countCategory ? {
+      category: countCategory,
+      value: res.totalCount,
+    } : null,
+    user: user || null,
+    uuid,
+  }));
+}
+
+/**
+ * Gets a portion of challenges from the backend.
+ * @param {String} uuid Should match an UUID stored into the state by
+ *  a previously dispatched GET_INIT action. Reducer will ignore the challenges
+ *  loaded by this action, if the UUID has already been removed from the set of
+ *  UUIDs of pending fetch challenge actions. Also, once the action results are
+ *  processed, its UUID is removed from the set of pending action UUIDs.
+ * @param {Object} filters Optional. An object with filters to pass to the
+ *  backend.
+ * @param {Object} params Optional. An object with params to pass to the backend
+ *  (except of the filter param, which is set by the previous argument).
+ * @param {String} token Optional. Auth token for Topcoder API v3. Some of the
+ *  challenges are visible only to the properly authenticated and authorized
+ *  users. With this argument omitted you will fetch only public challenges.
+ * @param {String} countCategory Optional. Specifies the category whereh the
+ *  total count of challenges returned by this request should be written.
+ * @param {String} user Optional. User handle. If specified, only challenges
+ *  where this user has some role are loaded.
+ * @return {Promise}
+ */
+function getChallenges(uuid, filters, params, token, countCategory, user) {
+  const service = getService(token);
+  const promise = user ?
+    service.getUserChallenges(user, filters, params) :
+    service.getChallenges(filters, params);
+  return handle(promise, uuid, filters, countCategory, user);
+}
+
+/**
+ * Writes specified UUID into the set of pending requests to load challenges.
+ * This allows (1) to understand whether we are waiting to load any challenges;
+ * (2) to cancel pending request by removing UUID from the set.
+ * @param {String} uuid
+ */
+function getInit(uuid) {
+  return uuid;
+}
+
+/**
+ * Gets a portion of marathon matches from the backend. Parameters are the same
+ * as for getChallenges() function.
+ * @param {String} uuid
+ * @param {Object} filters
+ * @param {Object} params
+ * @param {String} token
+ * @param {String} countCategory
+ * @param {String} user Optional. User handle. If specified, only challenges
+ *  where this user has some role are loaded.
+ * @param {Promise}
+ */
+function getMarathonMatches(uuid, filters, params, token, countCategory, user) {
+  const service = getService(token);
+  const promise = user ?
+    service.getUserMarathonMatches(user, filters, params) :
+    service.getMarathonMatches(filters, params);
+  return handle(promise, uuid, filters, countCategory, user);
+}
+
+/**
+ * This action tells Redux to remove all loaded challenges and to cancel
+ * any pending requests to load more challenges.
+ */
+function reset() {
+  return undefined;
+}
 
 export default createActions({
   CHALLENGE_LISTING: {
-    REMOVE_ALL_CHALLENGES: _.noop,
+    GET_CHALLENGES: getChallenges,
+    GET_INIT: getInit,
+    GET_MARATHON_MATCHES: getMarathonMatches,
+    RESET: reset,
   },
 });

--- a/src/shared/components/challenge-listing/index.jsx
+++ b/src/shared/components/challenge-listing/index.jsx
@@ -21,9 +21,6 @@ import PT from 'prop-types';
 import config from 'utils/config';
 import Sticky from 'react-stickynode';
 
-import { getService as getChallengesService } from 'services/challenges';
-
-import { DESIGN_TRACK, DEVELOP_TRACK, DATA_SCIENCE_TRACK } from './Filters/ChallengeFilter';
 import ChallengeFilterWithSearch from './Filters/ChallengeFilterWithSearch';
 import ChallengeFilters from './Filters/ChallengeFilters';
 import SideBarFilter, { MODE as SideBarFilterModes } from './SideBarFilters/SideBarFilter';
@@ -49,12 +46,6 @@ function keywordsMapper(keyword) {
     value: keyword,
   };
 }
-
-const communityMap = {
-  DEVELOP: DEVELOP_TRACK,
-  DESIGN: DESIGN_TRACK,
-  DATA_SCIENCE: DATA_SCIENCE_TRACK,
-};
 
 // Number of challenge placeholder card to display
 const CHALLENGE_PLACEHOLDER_COUNT = 8;
@@ -82,6 +73,7 @@ const SRMsSidebarMock = {
  * {param} limit: Number of challenges to fetch
  * {param} helper: Function to invoke to map response
  */
+/*
 function fetchPastChallenges(limit, helper, groupIds, tokenV3) {
   const cService = getChallengesService(tokenV3);
   const MAX_LIMIT = 50;
@@ -99,6 +91,7 @@ function fetchPastChallenges(limit, helper, groupIds, tokenV3) {
   }
   return result;
 }
+*/
 
 // helper function to serialize object to query string
 const serialize = filter => filter.getURLEncoded();
@@ -125,11 +118,9 @@ class ChallengeFiltersExample extends React.Component {
       currentCardType: 'Challenges',
       filter: new SideBarFilter(),
       lastFetchId: 0,
-      isLoaded: false,
+
       isSRMChallengesLoading: false,
       isSRMChallengesLoaded: false,
-      isChallengesLoading: false,
-      isChallengesLoaded: false,
     };
     if (props.filterFromUrl) {
       this.state.filter = deserialize(props.filterFromUrl);
@@ -188,10 +179,12 @@ class ChallengeFiltersExample extends React.Component {
    * load data only once.
    */
   componentDidMount() {
+    /*
     if (!this.state.isSRMChallengesLoading && !this.state.isSRMChallengesLoaded) {
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({ isSRMChallengesLoading: true });
       /* Fetching of SRM challenges */
+      /*
       fetch(`${this.props.config.API_URL}/srms/?filter=status=FUTURE`)
         .then(res => res.json())
         .then((json) => {
@@ -202,7 +195,9 @@ class ChallengeFiltersExample extends React.Component {
           });
         });
     }
+    */
 
+    /*
     if (!this.state.isChallengesLoading && !this.state.isChallengesLoaded) {
       // eslint-disable-next-line react/no-did-mount-set-state
       this.setState({ isChallengesLoading: true });
@@ -211,8 +206,10 @@ class ChallengeFiltersExample extends React.Component {
         this.setState({ isChallengesLoading: false, isChallengesLoaded: true });
       });
     }
+    */
   }
 
+  /*
   componentDidUpdate(prevProps) {
     if (this.props.auth.tokenV3 !== prevProps.auth.tokenV3) {
       setImmediate(() => {
@@ -233,6 +230,7 @@ class ChallengeFiltersExample extends React.Component {
       });
     }
   }
+  */
 
   /**
    * Searches the challenges for with the specified search string, competition
@@ -270,22 +268,6 @@ class ChallengeFiltersExample extends React.Component {
     this.setState({ filter: updatedFilter }, this.saveFiltersToHash.bind(this, updatedFilter));
   }
 
-  /**
-   * Writes array of challenges into the state.
-   * @param {Number} fetchId Nothing will be done, if this ID mismatches the one
-   *  stored in the state (this way we deal with async fetches: only the latest
-   *  fetch will be able to write its result into the state).
-   * @param {Array} challenges Array of challenge objects.
-   * @param {Function(Object)} filter An optional filter function. If provided,
-   *  the array of challenges, given as the second argument, will be prefiltered
-   *  with this function before writing into the state.
-   */
-  setChallenges(fetchId, challenges, filter) {
-    if (fetchId !== this.state.lastFetchId) return;
-    const c = filter ? challenges.filter(filter.getFilterFunction()) : challenges;
-    this.setState({ challenges: c, isLoaded: true });
-  }
-
   // set current card type
   setCardType(cardType) {
     this.setState({
@@ -302,144 +284,6 @@ class ChallengeFiltersExample extends React.Component {
     this.props.onSaveFilterToUrl(urlString);
   }
 
-  /**
-   * Fetches challenges from the backend API v2.
-   *
-   * As there is no single endpoint to fetch and filter challenges from all tracks,
-   * this function calls three separate enpoints (design, development, and dataScience
-   * science), and fetches all active challenges from each of them.
-   *
-   * As some of the challenges may belong to several tracks (currently some challenges
-   * are returned both for development and data science listings, although technically
-   * they are registered as development challenges), this function appends to all
-   * fetched challenges a new `communities` field, which is a set of all tracks a
-   * challenge belongs to, based on the endpoints which have returned that challenge.
-   *
-   * As pure data science challenges don't have in their objects some of the fields
-   * the challenges in other tracks have, this function also attaches some of the
-   * missing fields to them, in order to avoid the need for aditional conditions
-   * in the dependent code.
-   *
-   * @return Promise which resolves to the array of challenges.
-   */
-  fetchChallenges() {
-    const { auth } = this.props;
-    const challenges = [];
-    const knownKeywords = new Set();
-    VALID_KEYWORDS.forEach(item => knownKeywords.add(item.value));
-    const map = {};
-    let forceUpdate = false;
-    function helper1(key) {
-      if (knownKeywords.has(key)) return;
-      knownKeywords.add(key);
-      forceUpdate = true;
-    }
-    /* Normalizes challenge objects received from different API endpoints,
-     * and adds them to the list of loaded challenges. */
-    // TODO: Do we still need to pass api responses through this helper
-    // after we have moved to API V3?
-    function helper2(response, community) {
-      return response.json().then((res) => {
-        // TODO: API v3 always has res.result!
-        const content = res.result ? res.result.content : res.data;
-        content.forEach((item) => {
-          if (item.subTrack === 'MARATHON_MATCH') {
-            // TODO: After we have moved to API v3, most probably there is
-            // a more optimal way to set some of these defaults, or probably
-            // we can get rid of this method at all. Don't have time to
-            // investigate it carefully now.
-            const endTimestamp = new Date(item.endDate).getTime();
-            const allphases = [{
-              challengeId: item.id,
-              phaseType: 'Registration',
-              phaseStatus: endTimestamp > Date.now() ? 'Open' : 'Close',
-              scheduledEndTime: item.endDate,
-            }];
-            _.defaults(item, {
-              id: item.id,
-              name: item.name,
-              challengeCommunity: 'Data',
-              challengeType: 'Marathon',
-              allPhases: allphases,
-              currentPhases: allphases.filter(phase => phase.phaseStatus === 'Open'),
-              communities: new Set([community]),
-              currentPhaseName: endTimestamp > Date.now() ? 'Registration' : '',
-              numRegistrants: item.numRegistrants[0],
-              numSubmissions: item.userIds.length,
-              platforms: '',
-              prizes: [0],
-              registrationOpen: endTimestamp > Date.now() ? 'Yes' : 'No',
-              registrationStartDate: item.startDate,
-              submissionEndDate: item.endDate,
-              submissionEndTimestamp: endTimestamp,
-              technologies: '',
-              totalPrize: 0,
-              track: 'DATA_SCIENCE',
-              status: endTimestamp > Date.now() ? 'ACTIVE' : 'COMPLETED',
-              subTrack: 'MARATHON_MATCH',
-            });
-            map[item.id] = item;
-          } else if (item.track === 'SRM') {
-            /* We don't support SRM yet, so we don't want them around */
-          } else { /* All challenges from other endpoints have the same format. */
-            const existing = map[item.id];
-            const challengeCommunity = community || communityMap[item.track];
-            if (existing) existing.communities.add(challengeCommunity);
-            else {
-              _.defaults(item, {
-                communities: new Set([challengeCommunity]),
-                platforms: '',
-                registrationOpen: item.allPhases.filter(d => d.phaseType === 'Registration')[0].phaseStatus === 'Open' ? 'Yes' : 'No',
-                technologies: '',
-                submissionEndTimestamp: item.submissionEndDate,
-              });
-              map[item.id] = item;
-              if (item.platforms) {
-                item.platforms.split(',').forEach(helper1);
-              }
-              if (item.technologies) {
-                item.technologies.split(',').forEach(helper1);
-              }
-            }
-          }
-        });
-      },
-      );
-    }
-
-    const cService = getChallengesService(auth.tokenV3);
-    return Promise.all([
-      /* Fetching of active challenges */
-      cService.getChallenges({
-        groupIds: this.props.challengeGroupId || undefined,
-        status: 'ACTIVE',
-      }).then(res => helper2(res)),
-      cService.getMarathonMatches({
-        groupIds: this.props.challengeGroupId || undefined,
-        status: 'ACTIVE',
-      }).then(res => helper2(res, DATA_SCIENCE_TRACK)),
-
-      // Fetch some past challenges
-      ...fetchPastChallenges(400, helper2, this.props.challengeGroupId || undefined, auth.tokenV3),
-      cService.getMarathonMatches({
-        groupIds: this.props.challengeGroupId || undefined,
-        status: 'PAST',
-      }, {
-        limit: 100,
-      }).then(res => helper2(res, DATA_SCIENCE_TRACK)),
-    ]).then(() => {
-      _.forIn(map, item => challenges.push(item));
-      challenges.sort((a, b) => b.submissionEndDate - a.submissionEndDate);
-      // TODO: Using forceUpdate() in ReactJS is a bad practice. The reason here
-      // is that we need to update the component if we have updated the mock list
-      // VALID_KEYWORDS. In the real App the list of valid keywords will be passed
-      // via props from the parent component, and no force update will be necessary.
-      // Thus, it is a temporary solution, which will be changed later.
-      if (forceUpdate) this.forceUpdate();
-      return challenges;
-    });
-  }
-
   // TODO:
   // This method is not being used any more
   // and should be removed in future.
@@ -450,35 +294,26 @@ class ChallengeFiltersExample extends React.Component {
 
   // ReactJS render method.
   render() {
-    // TODO: This is bad code. Generation of myChallengesId array is O(N),
-    // using it to mark `My Challenges` using that array is O(N^2). Not that
-    // critical for now, as nobody has huge amount of challenges he is participating,
-    // but... One should generate a set of myChallengesId, which is O(N), and
-    // then use it to mark `My Challenges`, which also will be O(N).
-    let myChallengesId = [];
-    // get my challenges id
-    if (this.props.myChallenges) {
-      myChallengesId = this.props.myChallenges.map(challenge => challenge.id);
-    }
+    // console.log('RENDER', this.props);
 
-    let challenges = this.state.challenges;
+    let challenges = this.props.challenges;
     // filter all challenges by master filter before applying any user filters
     challenges = _.filter(challenges, this.props.masterFilterFunc);
     const currentFilter = this.state.filter;
-    challenges = challenges.map((item) => {
-      // check the challenge id exist in my challenges id
-      // TODO: This is also should be moved to a better place, fetchChallenges() ?
-      if (_.indexOf(myChallengesId, item.id) > -1) {
-        _.assign(item, { myChallenge: true });
-      }
-      return item;
-    });
+    if (this.props.auth.user) {
+      challenges = challenges.map((item) => {
+        if (item.users[this.props.auth.user.handle]) {
+          _.assign(item, { myChallenge: true });
+        }
+        return item;
+      });
+    }
 
     const { filter } = this.state;
     const { name: sidebarFilterName } = filter;
 
     let challengeCardContainer;
-    if (!this.state.isLoaded) {
+    if (this.props.loading) {
       const challengeCards = _.range(CHALLENGE_PLACEHOLDER_COUNT)
       .map(key => <ChallengeCardPlaceholder id={key} key={key} />);
       challengeCardContainer = (
@@ -631,7 +466,7 @@ class ChallengeFiltersExample extends React.Component {
 
         <div styleName={`tc-content-wrapper ${this.state.currentCardType === 'Challenges' ? '' : 'hidden'}`}>
           <div styleName="sidebar-container-mobile">
-            {this.state.isLoaded ? (<SideBarFilters
+            {!this.props.loading ? (<SideBarFilters
               config={this.props.config}
               challenges={challenges}
               filter={this.state.sidebarFilter}
@@ -654,7 +489,7 @@ class ChallengeFiltersExample extends React.Component {
 
           <div styleName="sidebar-container-desktop">
             <Sticky top={20}>
-              {this.state.isLoaded ? (<SideBarFilters
+              {!this.props.loading ? (<SideBarFilters
                 config={this.props.config}
                 challenges={challenges}
                 filter={this.state.filter}
@@ -693,13 +528,21 @@ ChallengeFiltersExample.defaultProps = {
 };
 
 ChallengeFiltersExample.propTypes = {
+  challenges: PT.arrayOf(PT.shape({
+
+  })).isRequired,
+  // getChallenges: PT.func.isRequired,
+  // getMarathonMatches: PT.func.isRequired,
+  loading: PT.bool.isRequired,
+
+  /* OLD PROPS BELOW */
   config: PT.shape({
     API_URL_V2: PT.string,
     API_URL: PT.string,
     MAIN_URL: PT.MAIN_URL,
     COMMUNITY_URL: PT.COMMUNITY_URL,
   }),
-  challengeGroupId: PT.string,
+  // challengeGroupId: PT.string,
   filterFromUrl: PT.string,
   onSaveFilterToUrl: PT.func,
   setChallengeFilter: PT.func,

--- a/src/shared/containers/ChallengeListing/index.jsx
+++ b/src/shared/containers/ChallengeListing/index.jsx
@@ -9,12 +9,15 @@
  * which is used to define which challenges should be listed for the certain community.
  */
 
+import _ from 'lodash';
+import actions from 'actions/challenge-listing';
 import React from 'react';
 import PT from 'prop-types';
 import { connect } from 'react-redux';
 import ChallengeFiltersExample from 'components/challenge-listing';
 import Banner from 'components/tc-communities/Banner';
 import NewsletterSignup from 'components/tc-communities/NewsletterSignup';
+import shortid from 'shortid';
 import style from './styles.scss';
 
 // The container component
@@ -22,8 +25,60 @@ class ChallengeListingPageContainer extends React.Component {
 
   constructor(props) {
     super(props);
-
     this.masterFilterFunc = this.masterFilterFunc.bind(this);
+  }
+
+  componentDidMount() {
+    this.loadChallenges();
+  }
+
+  componentDidUpdate(prevProps) {
+    const token = this.props.auth.tokenV3;
+    if (token && token !== prevProps.auth.tokenV3) {
+      setImmediate(() => this.loadChallenges());
+    }
+  }
+
+  loadChallenges() {
+    const { tokenV3, user } = this.props.auth;
+    const groupIds = this.props.challengeGroupId || undefined;
+
+    /* Initial loading of the challenges. Later we'll add some extra
+      conditions to prevent loading when data are up-to-date because
+      of server-side rendering, or because we have been at this page
+      recently. */
+
+    /* Active challenges. */
+    this.props.getChallenges({
+      groupIds,
+      status: 'ACTIVE',
+    }, {}, tokenV3, 'active');
+    this.props.getMarathonMatches({
+      groupIds,
+      status: 'ACTIVE',
+    }, {}, tokenV3, 'activeMM');
+
+    /* My active challenges. */
+    if (user) {
+      this.props.getChallenges({
+        groupIds,
+        status: 'ACTIVE',
+      }, {}, tokenV3, 'myActive', user.handle);
+      this.props.getMarathonMatches({
+        groupIds,
+        status: 'ACTIVE',
+      }, {}, tokenV3, 'myActiveMM', user.handle);
+    }
+
+    /* Past challenges. */
+    this.props.getChallenges({
+      groupIds,
+      status: 'COMPLETED',
+    }, {}, tokenV3, 'past');
+    this.props.getMarathonMatches({
+      groupIds,
+      status: 'PAST',
+    }, {}, tokenV3, 'pastMM');
   }
 
   /**
@@ -75,6 +130,12 @@ class ChallengeListingPageContainer extends React.Component {
         }
         {/* eslint-enable max-len */}
         <ChallengeFiltersExample
+          challenges={this.props.challengeListing.challenges}
+          getChallenges={this.props.getChallenges}
+          getMarathonMatches={this.props.getMarathonMatches}
+          loading={Boolean(_.keys(this.props.challengeListing.pendingRequests).length)}
+
+          /* OLD PROPS BELOW */
           challengeGroupId={challengeGroupId}
           filterFromUrl={this.props.location.hash}
           masterFilterFunc={this.masterFilterFunc}
@@ -104,6 +165,14 @@ ChallengeListingPageContainer.defaultProps = {
 };
 
 ChallengeListingPageContainer.propTypes = {
+  challengeListing: PT.shape({
+    challenges: PT.arrayOf(PT.shape({})).isRequired,
+    pendingRequests: PT.shape({}).isRequired,
+  }).isRequired,
+  getChallenges: PT.func.isRequired,
+  getMarathonMatches: PT.func.isRequired,
+
+  /* OLD PROPS BELOW */
   listingOnly: PT.bool,
   match: PT.shape({
     params: PT.shape({
@@ -119,16 +188,51 @@ ChallengeListingPageContainer.propTypes = {
     hash: PT.string,
   }).isRequired,
   auth: PT.shape({
+    tokenV3: PT.string,
     user: PT.shape(),
   }).isRequired,
 };
 
 const mapStateToProps = state => ({
   auth: state.auth,
+  challengeListing: state.challengeListing,
 });
+
+/**
+ * Callback for loading challenges satisfying to the specified criteria.
+ * All arguments starting from second should match corresponding arguments
+ * of the getChallenges action.
+ * @param {Function} dispatch
+ */
+function getChallenges(dispatch, ...rest) {
+  const uuid = shortid();
+  dispatch(actions.challengeListing.getInit(uuid));
+  dispatch(actions.challengeListing.getChallenges(uuid, ...rest));
+}
+
+/**
+ * Callback for loading marathon matches satisfying to the specified criteria.
+ * All arguments starting from second should match corresponding arguments
+ * of the getChallenges action.
+ * @param {Function} dispatch
+ */
+function getMarathonMatches(dispatch, ...rest) {
+  const uuid = shortid();
+  dispatch(actions.challengeListing.getInit(uuid));
+  dispatch(actions.challengeListing.getMarathonMatches(uuid, ...rest));
+}
+
+function mapDispatchToProps(dispatch) {
+  return {
+    getChallenges: (...rest) => getChallenges(dispatch, ...rest),
+    getMarathonMatches: (...rest) => getMarathonMatches(dispatch, ...rest),
+    reset: () => dispatch(actions.challengeListing.reset()),
+  };
+}
 
 const ChallengeListingContainer = connect(
   mapStateToProps,
+  mapDispatchToProps,
 )(ChallengeListingPageContainer);
 
 export default ChallengeListingContainer;

--- a/src/shared/reducers/challenge-listing.js
+++ b/src/shared/reducers/challenge-listing.js
@@ -1,0 +1,271 @@
+/**
+ * Reducer for state.challengeListing.
+ *
+ * This section of the state holds the following fields:
+ *
+ *  - challenges {Array} - Normalized challenge objects loaded from the
+ *    backend. Normalization means that we add extra fields to the challenge
+ *    and marathon match objects, received from different backend endpoints,
+ *    to ensure that the rest of the code can handle them in a uniform way,
+ *    and that we are able to filter them in all necessary ways (e.g., when
+ *    we fetch challenges belonging to a specific group, returned challenge
+ *    objects do not have group information; so we append group ids to these
+ *    objects to be able to filter them out by groups on the frontend side);
+ *
+ *  - counts {Object} - Total counts of challenges in the backend. This object
+ *    holds key - value pairs, where the key specifies a category and value
+ *    specifies the total count of challenges under that category;
+ *
+ *  - oldestData {Number} - Timestamp of the moment of reducer construction,
+ *    or of the last reset of this section of the state. This allows to
+ *    automatically refresh loaded challenge data from time to time to
+ *    ensure that displayed data are in reasonable sync with the backend.
+ *
+ *  - pendingRequests {Object} - Set of UUIDs of pending requests to
+ *    load challenge data. It allows
+ *    1. To see that we are loading something right now;
+ *    2. To cancel pending requests (reducer will ignore resolved actions
+ *       with UUID not present in this set at the time of resolution).
+ *    Technically it is stored as a map of UUIDs to boolean values,
+ *    as only plain objects can be safely stored into Redux state.
+ */
+
+import _ from 'lodash';
+import actions from 'actions/challenge-listing';
+import { handleActions } from 'redux-actions';
+import { COMMUNITY } from 'utils/tc';
+
+/**
+ * Normalizes a regular challenge object received from the backend.
+ * NOTE: This function is copied from the existing code in the challenge listing
+ * component. It is possible, that this normalization is not necessary after we
+ * have moved to Topcoder API v3, but it is kept for now to minimize a risk of
+ * breaking anything.
+ * @param {Object} challenge Challenge object received from the backend.
+ * @return {Object} Normalized challenge.
+ */
+function normalizeChallenge(challenge) {
+  const registrationOpen = challenge.allPhases.filter(d =>
+    d.phaseType === 'Registration',
+  )[0].phaseStatus === 'Open' ? 'Yes' : 'No';
+  return _.defaults(_.clone(challenge), {
+    communities: new Set([COMMUNITY[challenge.track]]),
+    platforms: '',
+    registrationOpen,
+    technologies: '',
+    submissionEndTimestamp: challenge.submissionEndDate,
+  });
+}
+
+/**
+ * Normalizes a marathon match challenge object received from the backend.
+ * NOTE: This function is copied from the existing code in the challenge listing
+ * component. It is possible, that this normalization is not necessary after we
+ * have moved to Topcoder API v3, but it is kept for now to minimize a risk of
+ * breaking anything.
+ * @param {Object} challenge MM challenge object received from the backend.
+ * @return {Object} Normalized challenge.
+ */
+function normalizeMarathonMatch(challenge) {
+  const endTimestamp = new Date(challenge.endDate).getTime();
+  const allphases = [{
+    challengeId: challenge.id,
+    phaseType: 'Registration',
+    phaseStatus: endTimestamp > Date.now() ? 'Open' : 'Close',
+    scheduledEndTime: challenge.endDate,
+  }];
+  return _.defaults(_.clone(challenge), {
+    challengeCommunity: 'Data',
+    challengeType: 'Marathon',
+    allPhases: allphases,
+    currentPhases: allphases.filter(phase => phase.phaseStatus === 'Open'),
+    communities: new Set([COMMUNITY.DATA_SCIENCE]),
+    currentPhaseName: endTimestamp > Date.now() ? 'Registration' : '',
+    numRegistrants: challenge.numRegistrants[0],
+    numSubmissions: challenge.userIds.length,
+    platforms: '',
+    prizes: [0],
+    registrationOpen: endTimestamp > Date.now() ? 'Yes' : 'No',
+    registrationStartDate: challenge.startDate,
+    submissionEndDate: challenge.endDate,
+    submissionEndTimestamp: endTimestamp,
+    technologies: '',
+    totalPrize: 0,
+    track: 'DATA_SCIENCE',
+    status: endTimestamp > Date.now() ? 'ACTIVE' : 'COMPLETED',
+    subTrack: 'MARATHON_MATCH',
+  });
+}
+
+/**
+ * Commong handling of all get challenge / get marathon matches actions.
+ * This function merges already normalized data into the array of loaded
+ * challenges.
+ * @param {Object} state
+ * @param {Object} action
+ * @param {Function} normalizer A function to use for normalization of
+ *  challenges contained in the payload to the common format expected by
+ *  the frontend.
+ * @return {Object} New state.
+ */
+function onGetDone(state, { payload }, normalizer) {
+  /* Tests whether we should accept the result of this action, and removes
+    UUID of this action from the set of pending actions. */
+  if (!state.pendingRequests[payload.uuid]) return state;
+  const pendingRequests = _.clone(state.pendingRequests);
+  delete pendingRequests[payload.uuid];
+
+  /* In case the payload holds a total count for some category of challenges,
+    we write this count into the state, probably overwritting the old value. */
+  let counts = state.counts;
+  if (payload.totalCount) {
+    counts = _.clone(counts);
+    counts[payload.totalCount.category] = payload.totalCount.value;
+  }
+
+  if (!payload.challenges || !payload.challenges.length) {
+    return {
+      ...state,
+      counts,
+      pendingRequests,
+    };
+  }
+
+  /* Merge of the known and received challenge data. First of all we reduce
+    the array of already loaded challenges to the map, to allow efficient
+    lookup. */
+  const challenges = {};
+  state.challenges.forEach((item) => {
+    challenges[item.id] = item;
+  });
+  payload.challenges.forEach((item) => {
+    const it = _.defaults(normalizer(item), {
+      groups: {},
+      users: {},
+    });
+
+    /* Challenge objects returned from the backend do not have list of
+      groups they belong to (to keep private groups secret). We know about
+      challenge - group associations because we specify groupIds filter in
+      the request. So, we add groups information, known to us, to the
+      challenge objects. */
+    if (_.get(payload, 'filters.groupIds')) {
+      payload.filters.groupIds.split(',').forEach((g) => {
+        it.groups[g] = true;
+      });
+    }
+
+    /* Similarly it happens with users participating in the challenges. */
+    if (payload.user) it.users[payload.user] = true;
+
+    /* If we already had some data about this challenge loaded, we should
+      properly merge-in the known information about groups and users. */
+    const old = challenges[it.id];
+    if (old) {
+      _.merge(it.groups, old.groups);
+      _.merge(it.users, old.users);
+    }
+
+    challenges[it.id] = it;
+  });
+
+  return {
+    ...state,
+    challenges: _.toArray(challenges),
+    counts,
+    pendingRequests,
+  };
+}
+
+/**
+ * Handles the CHALLENGE_LISTING/GET_INIT action.
+ * @param {Object} state
+ * @param {Object} action
+ * @return {Object} New state.
+ */
+function onGetInit(state, { payload }) {
+  if (state.pendingRequests[payload]) {
+    throw new Error('Request UUID is not unique.');
+  }
+  return {
+    ...state,
+    pendingRequests: {
+      ...state.pendingRequests,
+      [payload]: true,
+    },
+  };
+}
+
+/**
+ * Handling of CHALLENGE_LISTING/GET_CHALLENGES
+ * and CHALLENGE_LISTING/GET_USER_CHALLENGES actions.
+ * @param {Object} state
+ * @param {Object} action
+ * @return {Object} New state.
+ */
+function onGetChallenges(state, action) {
+  return onGetDone(state, action, normalizeChallenge);
+}
+
+/**
+ * Handling of CHALLENGE_LISTING/GET_MARATHON_MATCHES
+ * and CHALLENGE_LISTING/GET_USER_MARATHON_MATCHES actions.
+ * @param {Object} state
+ * @param {Object} action
+ * @return {Object} New state.
+ */
+function onGetMarathonMatches(state, action) {
+  return onGetDone(state, action, normalizeMarathonMatch);
+}
+
+/**
+ * Cleans received data from the state, and cancels any pending requests to
+ * fetch challenges. It does not reset total counts of challenges, as they
+ * are anyway will be overwritten with up-to-date values.
+ * @param {Object} state Previous state.
+ * @return {Object} New state.
+ */
+function onReset(state) {
+  return {
+    ...state,
+    challenges: [],
+    oldestData: Date.now(),
+    pendingRequests: {},
+  };
+}
+
+/**
+ * Creates a new Challenge Listing reducer with the specified initial state.
+ * @param {Object} initialState Optional. Initial state.
+ * @return Challenge Listing reducer.
+ */
+function create(initialState) {
+  const a = actions.challengeListing;
+  return handleActions({
+    [a.getChallenges]: onGetChallenges,
+    [a.getInit]: onGetInit,
+    [a.getMarathonMatches]: onGetMarathonMatches,
+    [a.reset]: onReset,
+  }, _.defaults(_.clone(initialState) || {}, {
+    challenges: [],
+    counts: {},
+    oldestData: Date.now(),
+    pendingRequests: {},
+  }));
+}
+
+/**
+ * The factory creates the new reducer with initial state tailored to the given
+ * ExpressJS HTTP request, if specified (for server-side rendering). If no HTTP
+ * request is specified, it creates the default reducer.
+ * @param {Object} req Optional. ExpressJS HTTP request.
+ * @return {Promise} Resolves to the new reducer.
+ */
+export function factory() {
+  /* Server-side rendering is not implemented yet.
+    Let's first ensure it all works fine without it. */
+  return Promise.resolve(create());
+}
+
+/* Default reducer with empty initial state. */
+export default create();

--- a/src/shared/reducers/index.js
+++ b/src/shared/reducers/index.js
@@ -18,6 +18,7 @@ import { combine, resolveReducers } from 'utils/redux';
 
 import { factory as authFactory } from './auth';
 import { factory as challengeFactory } from './challenge';
+import { factory as challengeListingFactory } from './challenge-listing';
 import { factory as examplesFactory } from './examples';
 import { factory as tcCommunitiesFactory } from './tc-communities';
 import { factory as leaderboardFactory } from './leaderboard';
@@ -27,6 +28,7 @@ export function factory(req) {
   return resolveReducers({
     auth: authFactory(req),
     challenge: challengeFactory(req),
+    challengeListing: challengeListingFactory(req),
     examples: examplesFactory(req),
     tcCommunities: tcCommunitiesFactory(req),
     leaderboard: leaderboardFactory(req),

--- a/src/shared/services/challenges.js
+++ b/src/shared/services/challenges.js
@@ -34,7 +34,14 @@ class ChallengesService {
         filter: qs.stringify(filters),
         ...params,
       };
-      return this.private.api.get(`${endpoint}?${qs.stringify(query)}`);
+      return this.private.api.get(`${endpoint}?${qs.stringify(query)}`)
+      .then(res => (res.ok ? res.json() : new Error(res.statusText)))
+      .then(res => (
+        res.result.status === 200 ? {
+          challenges: res.result.content,
+          totalCount: res.result.metadata.totalCount,
+        } : new Error(res.result.content)
+      ));
     };
 
     this.private = {

--- a/src/shared/utils/tc.js
+++ b/src/shared/utils/tc.js
@@ -1,6 +1,16 @@
 /**
  * Collection of small Topcoder-related functions.
  */
+
+/**
+ * Codes of the Topcoder communities.
+ */
+export const COMMUNITY = {
+  DATA_SCIENCE: 'datasci',
+  DESIGN: 'design',
+  DEVELOP: 'develop',
+};
+
 /**
  * Given a rating value, returns corresponding color.
  * @param {Number} rating Rating.


### PR DESCRIPTION
- Initial loading of challenges into the listing is done with Redux
actions / reducers / state;

- My challenges are fetched again.

- If navigation around the listing page triggers loading of additional
challenges, it is not handled properly (old fetch code is executed,
which can be kind of fine for the stand-alone listing, but definitely
not good for the listing inside TC communities).

- Challenge counts in the sidebar are wrong.

- In general there is a lot of room for further improvements.