### PR TITLE
Fixed issue #176

### DIFF
--- a/src/shared/utils/challenge-listing/filter.js
+++ b/src/shared/utils/challenge-listing/filter.js
@@ -326,6 +326,10 @@ export function removeTrack(state, track) {
     });
   }
   delete res.tracks[track];
+  /*As was stated in the 'addTrack' function, selecting all tracks is the same as having
+   no tracks field. So selecting no tracks should also be the same. Removing this line
+   causes no challenges to be returned and flickering of the empty challenge listings.*/ 
+  if (_.isEmpty(res.tracks)) delete res.tracks;
   return res;
 }
 

--- a/src/shared/utils/challenge-listing/filter.js
+++ b/src/shared/utils/challenge-listing/filter.js
@@ -326,9 +326,9 @@ export function removeTrack(state, track) {
     });
   }
   delete res.tracks[track];
-  /*As was stated in the 'addTrack' function, selecting all tracks is the same as having
-   no tracks field. So selecting no tracks should also be the same. Removing this line
-   causes no challenges to be returned and flickering of the empty challenge listings.*/ 
+  /* As was stated in the 'addTrack' function, selecting all tracks is the same as having
+   * no tracks field. So selecting no tracks should also be the same. Removing this line
+   * causes no challenges to be returned and flickering of the empty challenge listings. */ 
   if (_.isEmpty(res.tracks)) delete res.tracks;
   return res;
 }


### PR DESCRIPTION
When all types of contests (design, develepment, data science) are unselected the page should load all contests, but instead it loads it tries to search for and load no contests. It tries again over and over for a few minutes and eventually stops trying.

I added an if statement in the 'removeTracks' function to delete the 'tracks' field similar to what was done in the 'addTracks' function when all tracks are selected. In the comments in the code it said that selecting all tracks is the same as having no tracks field. So selecting no tracks should also be the same.

When all tracks are removed the tracks field becomes an empty array which seems to cause the problem. Deleting the tracks array (field) makes the other functions behave as they should and return all challenges.

local.topcoder.com/challenges?