### PR TITLE
Fixed issue #176

### DIFF
--- a/src/shared/utils/challenge-listing/filter.js
+++ b/src/shared/utils/challenge-listing/filter.js
@@ -302,6 +302,7 @@ export function combine(...filters) {
 export function mapToBackend(filter) {
   const res = {};
   if (filter.groupIds) res.groupIds = filter.groupIds.join(',');
+  if (filter.groupIds && filter.tracks !== {}) res.groupIds = '0';
 
   /* NOTE: Right now the frontend challenge filter by tag works different,
    * it looks for matches in the challenge name OR in the techs / platforms. */


### PR DESCRIPTION
I removed the code from the other pull request and then added and tested the recommended check to see if the tracks field is present and empty. When there are no entries in the tracks field the 'groupIds' is set to '0'. There is no group 0 so 0 challenges are returned immediately, eliminating the flickering.