### PR TITLE
FIX: "filter" query param for challenges API should not be double-url…

### DIFF
--- a/src/shared/services/challenges.js
+++ b/src/shared/services/challenges.js
@@ -114,7 +114,7 @@ class ChallengesService {
       params = {},
     ) => {
       const query = {
-        filter: qs.stringify(filters),
+        filter: qs.stringify(filters, { encode: false }),
         ...params,
       };
       return this.private.api.get(`${endpoint}?${qs.stringify(query)}`)


### PR DESCRIPTION
…-encoded