### PR TITLE
Put viewport meta tag on one line and remove spaces.

### DIFF
--- a/src/server/renderer.jsx
+++ b/src/server/renderer.jsx
@@ -64,10 +64,7 @@ export default (req, res) => {
           ${styles}
           <link rel="shortcut icon" href="/favicon.ico" />
           <meta charset="utf-8" />
-          <meta
-            content="width = device-width, initial-scale = 1.0"
-            name="viewport"
-          />
+          <meta content="width=device-width,initial-scale=1.0" name="viewport" />
           <!-- Start of topcoder Zendesk Widget script -->
           <script>/*<![CDATA[*/window.zEmbed||function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function(){a.push(arguments)},window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try{o=s}catch(e){n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}o.open()._l=function(){var e=this.createElement("script");n&&(this.domain=n),e.id="js-iframe-async",e.src="https://assets.zendesk.com/embeddable_framework/main.js",this.t=+new Date,this.zendeskHost="topcoder.zendesk.com",this.zEQueue=a,this.body.appendChild(e)},o.write('<body onload="document._l();">'),o.close()}();
           /*]]>*/</script>


### PR DESCRIPTION
Put viewport meta tag on one line as discovered here:
https://stackoverflow.com/a/18892053/4930982

Also, remove spaces in content because Safari wants a comma-separated list but other browsers can split on spaces.  See https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag