### PR TITLE
Use api v3 for challenge register and unregister #479

### DIFF
--- a/src/shared/actions/challenge.js
+++ b/src/shared/actions/challenge.js
@@ -85,7 +85,7 @@ function getSubmissionsDone(challengeId, tokenV2) {
  * @return {Promise}
  */
 function registerDone(auth, challengeId) {
-  return getChallengesService(undefined, auth.tokenV2)
+  return getChallengesService(auth.tokenV3, auth.tokenV2)
     .register(challengeId)
     /* As a part of registration flow we silently update challenge details,
      * reusing for this purpose the corresponding action handler. */
@@ -99,7 +99,7 @@ function registerDone(auth, challengeId) {
  * @return {Promise}
  */
 function unregisterDone(auth, challengeId) {
-  return getChallengesService(undefined, auth.tokenV2)
+  return getChallengesService(auth.tokenV3, auth.tokenV2)
     .unregister(challengeId)
     /* As a part of unregistration flow we silently update challenge details,
      * reusing for this purpose the corresponding action handler. */

--- a/src/shared/actions/challenge.js
+++ b/src/shared/actions/challenge.js
@@ -85,7 +85,7 @@ function getSubmissionsDone(challengeId, tokenV2) {
  * @return {Promise}
  */
 function registerDone(auth, challengeId) {
-  return getChallengesService(auth.tokenV3, auth.tokenV2)
+  return getChallengesService(auth.tokenV3)
     .register(challengeId)
     /* As a part of registration flow we silently update challenge details,
      * reusing for this purpose the corresponding action handler. */
@@ -99,7 +99,7 @@ function registerDone(auth, challengeId) {
  * @return {Promise}
  */
 function unregisterDone(auth, challengeId) {
-  return getChallengesService(auth.tokenV3, auth.tokenV2)
+  return getChallengesService(auth.tokenV3)
     .unregister(challengeId)
     /* As a part of unregistration flow we silently update challenge details,
      * reusing for this purpose the corresponding action handler. */

--- a/src/shared/services/challenges.js
+++ b/src/shared/services/challenges.js
@@ -503,7 +503,7 @@ class ChallengesService {
    */
   async register(challengeId) {
     const endpoint = `/challenges/${challengeId}/register`;
-    const res = await this.private.apiV2.postJson(endpoint);
+    const res = await this.private.api.postJson(endpoint);
     if (!res.ok) throw new Error(res.statusText);
     return res.json();
   }
@@ -515,7 +515,7 @@ class ChallengesService {
    */
   async unregister(challengeId) {
     const endpoint = `/challenges/${challengeId}/unregister`;
-    const res = await this.private.apiV2.post(endpoint);
+    const res = await this.private.api.post(endpoint);
     if (!res.ok) throw new Error(res.statusText);
     return res.json();
   }


### PR DESCRIPTION
Fixes #479 


I made sure that unregistering from a challenge works but when I was trying to test registering a challenge, I keep getting a `Invalid URL http://localhost:3000/challenges/30051410/?type=develop` error. Not sure what's wrong with that.