### PR TITLE
Suppress warning mismatch between server and client render #603

### DIFF
--- a/src/shared/utils/router/SplitRoute.jsx
+++ b/src/shared/utils/router/SplitRoute.jsx
@@ -117,6 +117,7 @@ export default class SplitRoute extends React.Component {
                   dangerouslySetInnerHTML={{
                     __html: window.SPLITS[`${TMP_CHUNK_PREFIX}/${chunkName}`],
                   }}
+                  suppressHydrationWarning
                 />
               );
               /* eslint-disable react/no-danger */


### PR DESCRIPTION
Fixes #603 

I was able to get rid of the warning due to the mismatch between client and server rendered `LoadingIndicator` by [this change](suppressHydrationWarning) but I am not entirely sure if it is okay as it will hide all hydration warnings thrown by react if we have any.