### PR TITLE
Fix veterans challenge link to default to veterans only

### DIFF
--- a/src/server/tc-communities/veterans/metadata.json
+++ b/src/server/tc-communities/veterans/metadata.json
@@ -22,7 +22,7 @@
       "url": "/learn"
     }, {
       "title": "Challenges",
-      "url": "/challenges"
+      "url": "/challenges?communityId=veterans"
     }
   ],
   "footerText": "© Copyright Topcoder Inc 2017",


### PR DESCRIPTION
Swapped metadata from 
}, {
      "title": "Challenges",
      "url": "/challenges"
    }

to 

}, {
      "title": "Challenges",
      "url": "/challenges?communityId=veterans"
    }