### PR TITLE
Fix for Profile Settings - email change verification issue

### DIFF
--- a/src/shared/components/Settings/Account/MyAccount/EmailVerifiResult/Failed/index.jsx
+++ b/src/shared/components/Settings/Account/MyAccount/EmailVerifiResult/Failed/index.jsx
@@ -6,16 +6,16 @@ import { PrimaryButton } from 'topcoder-react-ui-kit';
  */
 import './styles.scss';
 
-let assets;
+let failureAsset;
 if (isomorphy.isClientSide()) {
-  assets = require.context('assets/images/account/email', false, /svg/);
+  failureAsset = require.context('assets/images/account/email', false, /svg/)('./failed.svg');
 }
 
 const Failed = () => (
   <div styleName="outer-container">
     <div styleName="page">
       <div styleName="container">
-        <img src={assets('./failed.svg')} alt="failed-icon" />
+        <img src={failureAsset} alt="failed-icon" />
         <h1>
           Email Verification Failed
         </h1>


### PR DESCRIPTION
Fix for Issue #1155   

Fixing the page error ("assets is not a function") upon choosing "I Disagree" link on received verification email after changing email in profile setting.
  
Email Verification Failed page is now shown correctly.  
