### PR TITLE
Issue #980: Member profile: Order of icons under profile photo should be the same as the Track and subtracks list

### DIFF
--- a/src/shared/containers/Profile.jsx
+++ b/src/shared/containers/Profile.jsx
@@ -48,6 +48,20 @@ class ProfileContainer extends React.Component {
       return <Error404 />;
     }
 
+    if (info && info.tracks && info.tracks.length > 0) {
+      const trackRankings = {
+        COPILOT: 0,
+        DATA_SCIENCE: 1,
+        DESIGN: 2,
+        DEVELOP: 3,
+      };
+      info.tracks.sort((track1, track2) => {
+        const track1Ranking = trackRankings[track1];
+        const track2Ranking = trackRankings[track2];
+        return track2Ranking - track1Ranking;
+      });
+    }
+
     return achievements && info && skills && stats
       ? (
         <ProfilePage


### PR DESCRIPTION
- Sort profile tracks