### PR TITLE
fix issue #1003

### DIFF
--- a/src/shared/components/ProfilePage/StatsCategory/index.jsx
+++ b/src/shared/components/ProfilePage/StatsCategory/index.jsx
@@ -143,7 +143,7 @@ Rating
                       && (
                       <div styleName="ranking">
                         <div style={{ color: '#21b2f1' }} styleName="number">
-                          {subtrack.wins}
+                          {subtrack.wins ? subtrack.wins : 0}
                         </div>
                         <div styleName="tag">
 Wins


### PR DESCRIPTION
fix issue #1003
Chrome –members –Idea Generation “0 wins” is not getting displayed in summary view