### PR TITLE
Fix side bar `here` link spacing

### DIFF
--- a/src/shared/components/challenge-detail/Specification/SideBar/index.jsx
+++ b/src/shared/components/challenge-detail/Specification/SideBar/index.jsx
@@ -224,7 +224,8 @@ Fonts:
             <p styleName="link-like-paragraph">
               All fonts within your design must be declared when you submit.
               DO NOT include any font files in your submission or source files.
-              Read about the font policy&nbsp;
+              Read about the font policy
+              {' '}
               <a href="https://help.topcoder.com/hc/en-us/articles/217959447-Font-Policy-for-Design-Challenges">
                 here.
               </a>
@@ -237,7 +238,8 @@ Screening:
               holder picks winners. Don
               {"'"}
 t let your hard work go to waste.
-              Learn more about how to pass screening&nbsp;
+              Learn more about how to pass screening
+              {' '}
               <a href="https://help.topcoder.com/hc/en-us/articles/217959577-How-to-Pass-Screening-in-Design-Challenges">
                 here.
               </a>

--- a/src/shared/components/challenge-detail/Specification/SideBar/index.jsx
+++ b/src/shared/components/challenge-detail/Specification/SideBar/index.jsx
@@ -224,7 +224,7 @@ Fonts:
             <p styleName="link-like-paragraph">
               All fonts within your design must be declared when you submit.
               DO NOT include any font files in your submission or source files.
-              Read about the font policy
+              Read about the font policy&nbsp;
               <a href="https://help.topcoder.com/hc/en-us/articles/217959447-Font-Policy-for-Design-Challenges">
                 here.
               </a>
@@ -237,7 +237,7 @@ Screening:
               holder picks winners. Don
               {"'"}
 t let your hard work go to waste.
-              Learn more about how to pass screening
+              Learn more about how to pass screening&nbsp;
               <a href="https://help.topcoder.com/hc/en-us/articles/217959577-How-to-Pass-Screening-in-Design-Challenges">
                 here.
               </a>


### PR DESCRIPTION
Challenge details page sidebar had the link ‘here’ without proper spacing in the paragraph 