### PR TITLE
Fix for Issue #2910 - Don't read out title when menu open

### DIFF
--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -47,6 +47,7 @@ export default function ChallengeHeader(props) {
     selectedView,
     showDeadlineDetail,
     hasFirstPlacement,
+    isMenuOpened,
   } = props;
 
   const {
@@ -239,7 +240,7 @@ export default function ChallengeHeader(props) {
   return (
     <div styleName="challenge-outer-container">
       <div styleName="important-detail">
-        <div styleName="title-wrapper">
+        <div styleName="title-wrapper" aria-hidden={isMenuOpened}>
           <Link to={challengesUrl}>
             <LeftArrow styleName="left-arrow" />
           </Link>
@@ -421,6 +422,7 @@ Show Deadlines
 
 ChallengeHeader.defaultProps = {
   checkpoints: {},
+  isMenuOpened: false,
 };
 
 ChallengeHeader.propTypes = {
@@ -442,4 +444,5 @@ ChallengeHeader.propTypes = {
   unregistering: PT.bool.isRequired,
   challengeSubtracksMap: PT.shape().isRequired,
   hasFirstPlacement: PT.bool.isRequired,
+  isMenuOpened: PT.bool,
 };

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -234,6 +234,7 @@ class ChallengeDetailPageContainer extends React.Component {
       unregisterFromChallenge,
       unregistering,
       updateChallenge,
+      isMenuOpened,
     } = this.props;
 
     const {
@@ -327,6 +328,7 @@ does not exist!
               hasRegistered={hasRegistered}
               hasFirstPlacement={hasFirstPlacement}
               challengeSubtracksMap={challengeSubtracksMap}
+              isMenuOpened={isMenuOpened}
             />
             )
           }
@@ -414,6 +416,7 @@ ChallengeDetailPageContainer.defaultProps = {
   // loadingCheckpointResults: false,
   results: null,
   terms: [],
+  isMenuOpened: false,
 };
 
 ChallengeDetailPageContainer.propTypes = {
@@ -456,6 +459,7 @@ ChallengeDetailPageContainer.propTypes = {
   unregisterFromChallenge: PT.func.isRequired,
   unregistering: PT.bool.isRequired,
   updateChallenge: PT.func.isRequired,
+  isMenuOpened: PT.bool,
 };
 
 function mapStateToProps(state, props) {
@@ -489,6 +493,7 @@ function mapStateToProps(state, props) {
     specsTabState: state.page.challengeDetails.specsTabState,
     terms: state.terms.terms,
     unregistering: state.challenge.unregistering,
+    isMenuOpened: !!state.topcoderHeader.openedMenu,
   };
 }
 


### PR DESCRIPTION
#2910 
Hide contest title from screen reader when menu is opened.