### PR TITLE
Fix #2872 - Sample challenge page: The 'arrow' which when clicked

### DIFF
--- a/src/assets/images/ico-arrow-big-left.svg
+++ b/src/assets/images/ico-arrow-big-left.svg
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="12px" height="19px" viewBox="0 0 12 19" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
     <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
-    <title>ico-arrow-big-left</title>
-    <desc>Created with Sketch.</desc>
     <defs></defs>
     <g id="ASSETS-EXPORT" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
         <g id="Assets" sketch:type="MSArtboardGroup" transform="translate(-950.000000, -252.000000)" fill="#A3A3AE">

--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -241,7 +241,7 @@ export default function ChallengeHeader(props) {
     <div styleName="challenge-outer-container">
       <div styleName="important-detail">
         <div styleName="title-wrapper" aria-hidden={isMenuOpened}>
-          <Link to={challengesUrl}>
+          <Link to={challengesUrl} aria-label="Back to challenge list">
             <LeftArrow styleName="left-arrow" />
           </Link>
           <div>


### PR DESCRIPTION
Sample challenge page: The 'arrow' which when clicked takes the user back to the challenge feed page is being read as 'ico-arrow-big-left' by screen readers. 