### PR TITLE
Fix for Issue #3978 Leaderboard page goes blank

### DIFF
--- a/__tests__/shared/components/Leaderboard/__snapshots__/Podium.jsx.snap
+++ b/__tests__/shared/components/Leaderboard/__snapshots__/Podium.jsx.snap
@@ -29,6 +29,7 @@ exports[`Matches shallow shapshot 1`] = `
         isCopilot={false}
         isTopGear={false}
         onUsernameClick={null}
+        themeName="Default"
       />
     </div>
     <div
@@ -48,6 +49,7 @@ exports[`Matches shallow shapshot 1`] = `
         isCopilot={false}
         isTopGear={false}
         onUsernameClick={null}
+        themeName="Default"
       />
     </div>
     <div
@@ -67,6 +69,7 @@ exports[`Matches shallow shapshot 1`] = `
         isCopilot={false}
         isTopGear={false}
         onUsernameClick={null}
+        themeName="Default"
       />
     </div>
     <div
@@ -86,6 +89,7 @@ exports[`Matches shallow shapshot 1`] = `
         isCopilot={false}
         isTopGear={false}
         onUsernameClick={null}
+        themeName="Default"
       />
     </div>
   </div>

--- a/src/shared/components/Leaderboard/PodiumSpot/index.jsx
+++ b/src/shared/components/Leaderboard/PodiumSpot/index.jsx
@@ -228,4 +228,5 @@ PodiumSpot.defaultProps = {
   onUsernameClick: null,
   isTopGear: false,
   isAlgo: false,
+  themeName: 'Default',
 };

--- a/src/shared/components/Leaderboard/PodiumSpot/index.jsx
+++ b/src/shared/components/Leaderboard/PodiumSpot/index.jsx
@@ -220,7 +220,7 @@ PodiumSpot.propTypes = {
   onUsernameClick: PT.func,
   isTopGear: PT.bool,
   isAlgo: PT.bool,
-  themeName: PT.string.isRequired,
+  themeName: PT.string,
 };
 
 PodiumSpot.defaultProps = {


### PR DESCRIPTION
#3978   

Set up default value of themeName property in PodiumSpot component to fix the issue of Leaderboard table page goes blank.