### PR TITLE
Issue #4093 - Dev mode issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12130,7 +12130,7 @@
         "moment": "2.24.0",
         "prop-types": "15.7.2",
         "react-resize-detector": "4.2.1",
-        "topcoder-react-utils": "0.7.9"
+        "topcoder-react-utils": "0.7.8"
       },
       "dependencies": {
         "config": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "start": "cross-env BABEL_ENV=production NODE_ENV=production node ./bin/www",
     "test": "npm run lint && npm run jest",
     "commitlint": "commitlint -E HUSKY_GIT_PARAMS",
-    "release:changelog": "npm run conventional-changelog -- -p angular -i CHANGELOG.md -s"
+    "release:changelog": "npm run conventional-changelog -- -p angular -i CHANGELOG.md -s",
+    "postinstall": "rimraf node_modules/navigation-component/node_modules/topcoder-react-utils && rimraf node_modules/topcoder-react-ui-kit/node_modules/topcoder-react-utils"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add postinstall script to remove nested topcoder-react-utils dependency from navigation-component and topcoder-react-ui-kit.

#4093 

The issue is caused by the version of topcoder-react-utils component being used by navigation-component (0.7.9) and topcoder-react-ui-kit (^0.7.8) is higher than the one used by community-app (0.7.8)

https://github.com/topcoder-platform/topcoder-react-ui-kit/blob/dc6ce000568412665ab98e1a08980c24a0d8e4a1/package.json#L41  
https://github.com/topcoder-platform/navigation-component/blob/cbe727f4eea63b1bc992ba03c5f93f932d905de1/package.json#L68  

For a quick solution, we can manually delete nested topcoder-react-utils folder inside the nested node_modules of those two components.

I've added postinstall command to remove those nested dependency.
It will be executed every after npm install command, or simply execute it directly via npm run postinstall

Of course, the elegant solution is to create new branch for each those two components to use the matching version of topcoder-react-utils.
