### PR TITLE
Fix issue 4291, add subTrack 'DEVELOP_MARATHON_MATCH' to valid 'DEVELOP' tracks.

### DIFF
--- a/src/shared/utils/memberStats.js
+++ b/src/shared/utils/memberStats.js
@@ -418,6 +418,7 @@ export function isValidTrack(track, subTrack) {
       return subTrack === 'COPILOT';
     case 'DEVELOP':
       switch (subTrack) {
+        case 'DEVELOP_MARATHON_MATCH':
         case 'UI_PROTOTYPE_COMPETITION':
         case 'ASSEMBLY_COMPETITION':
         case 'FIRST_2_FINISH':


### PR DESCRIPTION
Fix issue 4291, add subTrack 'DEVELOP_MARATHON_MATCH' to valid 'DEVELOP' tracks.