### PR TITLE
refactor(dashboard): remove legacy links

### DIFF
--- a/__tests__/shared/components/Dashboard/SRM/__snapshots__/index.jsx.snap
+++ b/__tests__/shared/components/Dashboard/SRM/__snapshots__/index.jsx.snap
@@ -61,11 +61,6 @@ exports[`Matches shallow shapshot 1`] = `
     className="src-shared-components-Dashboard-SRM-___styles__srms-links___JFdeQ"
   >
     <a
-      href="https://www.topcoder-dev.com/my-srms/"
-    >
-      View Past SRMS
-    </a>
-    <a
       href="https://arena.topcoder-dev.com"
     >
       Launch Arena

--- a/src/shared/components/Dashboard/CurrentActivity/Challenges/index.jsx
+++ b/src/shared/components/Dashboard/CurrentActivity/Challenges/index.jsx
@@ -140,14 +140,6 @@ export default function Challenges({
           />
         </Sticky>
       </div>
-      <div styleName="linksContainer">
-        <a
-          href={`${config.URL.BASE}/my-challenges/?status=completed`}
-          styleName="link"
-        >
-          Past Challenges
-        </a>
-      </div>
     </div>
   );
 }

--- a/src/shared/components/Dashboard/CurrentActivity/Challenges/style.scss
+++ b/src/shared/components/Dashboard/CurrentActivity/Challenges/style.scss
@@ -21,26 +21,6 @@
   }
 }
 
-.link {
-  @include tc-body-md;
-
-  &,
-  &:active,
-  &:focus,
-  &:visited {
-    color: $tc-dark-blue-110;
-  }
-
-  &:hover {
-    color: $tc-dark-blue-70;
-  }
-}
-
-.linksContainer {
-  padding: 30px 20px 0;
-  text-align: center;
-}
-
 .loading {
   margin: 40px 20px 30px;
 }

--- a/src/shared/components/Dashboard/SRM/index.jsx
+++ b/src/shared/components/Dashboard/SRM/index.jsx
@@ -43,9 +43,6 @@ const SRM = (props) => {
         </div>
       </section>
       <div styleName="srms-links">
-        <a href={`${config.URL.BASE}/my-srms/`}>
-          View Past SRMS
-        </a>
         <a href={config.URL.ARENA}>
           Launch Arena
         </a>


### PR DESCRIPTION
Remove `View Past SRMS` and `Past Challenges` links from dashboard.

Closes topcoder-platform/community-app#4470