### PR TITLE
Fix Issue#4650 : Pass old groups ids to filter

### DIFF
--- a/src/shared/actions/tc-communities/index.js
+++ b/src/shared/actions/tc-communities/index.js
@@ -38,7 +38,7 @@ function getListInit(uuid) {
  * @return {Promise}
  */
 function getListDone(uuid, auth) {
-  const groups = _.get(auth, 'profile.groups', []).map(g => g.id);
+  const groups = _.get(auth, 'profile.groups', []).map(g => g.oldId);
   return getCommunitiesService(auth.tokenV3)
     .getList(groups).then(list => ({ list, uuid }));
 }


### PR DESCRIPTION
Issue: https://github.com/topcoder-platform/community-app/issues/4650

Dependency: https://github.com/topcoder-platform/topcoder-react-lib/pull/211