### PR TITLE
updated isZurichCompetitor to use group 'oldId' instead 'id'

### DIFF
--- a/src/shared/components/tc-communities/Header/index.jsx
+++ b/src/shared/components/tc-communities/Header/index.jsx
@@ -55,7 +55,7 @@ function Header(props) {
   const AUTH_URL = config.URL.AUTH;
   const normalizedProfile = profile && _.clone(profile);
   const isZurichCompetitor = (profile && profile.groups) ? _.intersection(
-    _.map(profile.groups, 'id'),
+    _.map(profile.groups, 'oldId'),
     meta.competitorsGroupIds,
   ) : [];
 


### PR DESCRIPTION
Issue: https://github.com/topcoder-platform/community-app/issues/4783