### PR TITLE
fix(challenge-listing): my challenges bucket/filter

### DIFF
--- a/__tests__/shared/components/challenge-listing/__snapshots__/index.jsx.snap
+++ b/__tests__/shared/components/challenge-listing/__snapshots__/index.jsx.snap
@@ -43,7 +43,6 @@ exports[`Matches shallow shapshot 1 shapshot 1 1`] = `
       setFilterState={[MockFunction]}
       setSort={[MockFunction]}
       sorts={Object {}}
-      userChallenges={Array []}
     />
     <div
       className="src-shared-components-challenge-listing-___style__sidebar-container-desktop___h0bz6"

--- a/src/shared/components/challenge-listing/Listing/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/index.jsx
@@ -21,7 +21,6 @@ function Listing({
   auth,
   challenges,
   challengeTypes,
-  userChallenges,
   challengesUrl,
   communityName,
   extraBucket,
@@ -47,7 +46,7 @@ function Listing({
   pastSearchTimestamp,
   isLoggedIn,
 }) {
-  const buckets = getBuckets(userChallenges);
+  const buckets = getBuckets(_.get(auth, 'user.userId'));
   const isChallengesAvailable = (bucket) => {
     const filter = Filter.getFilterFunction(buckets[bucket].filter);
     const clonedChallenges = _.clone(challenges);
@@ -180,7 +179,6 @@ Listing.defaultProps = {
   // onExpandFilterResult: _.noop,
   openChallengesInNewTabs: false,
   pastSearchTimestamp: 0,
-  userChallenges: [],
 };
 
 Listing.propTypes = {
@@ -216,7 +214,6 @@ Listing.propTypes = {
   setSort: PT.func.isRequired,
   sorts: PT.shape().isRequired,
   pastSearchTimestamp: PT.number,
-  userChallenges: PT.arrayOf(PT.string),
   isLoggedIn: PT.bool.isRequired,
 };
 

--- a/src/shared/components/challenge-listing/index.jsx
+++ b/src/shared/components/challenge-listing/index.jsx
@@ -115,7 +115,6 @@ export default function ChallengeListing(props) {
         sorts={props.sorts}
         loadMoreActive={props.loadMoreActive}
         loadingActiveChallenges={props.loadingChallenges}
-        userChallenges={props.userChallenges}
         isLoggedIn={isLoggedIn}
       />
     );
@@ -170,7 +169,6 @@ ChallengeListing.defaultProps = {
   expandTag: null,
   loadMoreActive: null,
   isBucketSwitching: false,
-  userChallenges: [],
 };
 
 ChallengeListing.propTypes = {
@@ -207,6 +205,5 @@ ChallengeListing.propTypes = {
   auth: PT.shape(),
   loadMoreActive: PT.func,
   isBucketSwitching: PT.bool,
-  userChallenges: PT.arrayOf(PT.string),
   isLoggedIn: PT.bool.isRequired,
 };

--- a/src/shared/containers/challenge-listing/Listing/index.jsx
+++ b/src/shared/containers/challenge-listing/Listing/index.jsx
@@ -149,7 +149,6 @@ export class ListingContainer extends React.Component {
       auth,
       getActiveChallenges,
       lastRequestedPageOfActiveChallenges,
-      getUserChallenges,
     } = this.props;
     const f = this.getBackendFilter();
     getActiveChallenges(
@@ -158,10 +157,6 @@ export class ListingContainer extends React.Component {
       auth.tokenV3,
       f.front,
     );
-    if (auth.tokenV3) {
-      const userId = _.get(auth.user, 'userId');
-      getUserChallenges(userId, auth.tokenV3);
-    }
   }
 
   render() {
@@ -209,7 +204,6 @@ export class ListingContainer extends React.Component {
       sorts,
       hideTcLinksInSidebarFooter,
       isBucketSwitching,
-      userChallenges,
     } = this.props;
 
     const { tokenV3 } = auth;
@@ -312,7 +306,6 @@ export class ListingContainer extends React.Component {
           groupIds={groupIds}
           auth={auth}
           isBucketSwitching={isBucketSwitching}
-          userChallenges={userChallenges}
           isLoggedIn={isLoggedIn}
         />
       </div>
@@ -340,7 +333,6 @@ ListingContainer.defaultProps = {
   queryBucket: BUCKETS.ALL,
   meta: {},
   isBucketSwitching: false,
-  userChallenges: [],
 };
 
 ListingContainer.propTypes = {
@@ -410,8 +402,6 @@ ListingContainer.propTypes = {
   meta: PT.shape(),
   isBucketSwitching: PT.bool,
   selectBucketDone: PT.func.isRequired,
-  userChallenges: PT.arrayOf(PT.string),
-  getUserChallenges: PT.func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -455,7 +445,6 @@ const mapStateToProps = (state, ownProps) => {
     isBucketSwitching: cl.sidebar.isBucketSwitching,
     expandedTags: cl.expandedTags,
     meta: cl.meta,
-    userChallenges: cl.userChallenges,
   };
 };
 
@@ -502,11 +491,6 @@ function mapDispatchToProps(dispatch) {
     setSort: (bucket, sort) => dispatch(a.setSort(bucket, sort)),
     markHeaderMenu: () => dispatch(ah.setCurrentNav('Compete', 'All Challenges')),
     expandTag: id => dispatch(a.expandTag(id)),
-    getUserChallenges: (userId, tokenV3) => {
-      const uuid = shortId();
-      dispatch(a.getUserChallengesInit(uuid));
-      dispatch(a.getUserChallengesDone(userId, tokenV3));
-    },
   };
 }
 

--- a/src/shared/containers/challenge-listing/Sidebar.jsx
+++ b/src/shared/containers/challenge-listing/Sidebar.jsx
@@ -57,12 +57,12 @@ export class SidebarContainer extends React.Component {
       setFilter,
       setSearchText,
       tokenV2,
+      user,
       updateAllSavedFilters,
       updateSavedFilter,
-      userChallenges,
     } = this.props;
 
-    const buckets = getBuckets(userChallenges);
+    const buckets = getBuckets(_.get(user, 'userId', null));
 
     if (extraBucket) {
       buckets[extraBucket.name] = extraBucket;
@@ -115,7 +115,6 @@ SidebarContainer.defaultProps = {
   selectedCommunityId: '',
   tokenV2: null,
   user: null,
-  userChallenges: [],
 };
 
 SidebarContainer.propTypes = {
@@ -136,7 +135,6 @@ SidebarContainer.propTypes = {
   updateAllSavedFilters: PT.func.isRequired,
   updateSavedFilter: PT.func.isRequired,
   user: PT.shape(),
-  userChallenges: PT.arrayOf(PT.string),
 };
 
 function mapDispatchToProps(dispatch) {
@@ -169,7 +167,6 @@ function mapStateToProps(state, ownProps) {
     selectedCommunityId: state.challengeListing.selectedCommunityId,
     tokenV2: state.auth.tokenV2,
     user: state.auth.user,
-    userChallenges: state.challengeListing.userChallenges,
   };
 }
 

--- a/src/shared/utils/challenge-listing/buckets.js
+++ b/src/shared/utils/challenge-listing/buckets.js
@@ -134,9 +134,9 @@ export const NO_LIVE_CHALLENGES_CONFIG = {
  * @param {String} userId id of the authenticated
  * user to filter out My Challenges.
  */
-export function getBuckets(userChallenges) {
+export function getBuckets(userId) {
   const res = _.cloneDeep(BUCKET_DATA);
-  res[BUCKETS.MY].filter.userChallenges = userChallenges;
+  res[BUCKETS.MY].filter.userId = userId;
   return res;
 }
 

--- a/src/shared/utils/challenge-listing/helper.js
+++ b/src/shared/utils/challenge-listing/helper.js
@@ -29,3 +29,26 @@ export function phaseStartDate(phase) {
   // For all other cases, take the `actualStartDate` as phase is already started
   return new Date(phase.actualStartDate);
 }
+
+/**
+ * Map user details with challenges
+ *
+ * @param {String} userId user id
+ * @param {Array} challenges all challenges
+ * @param {Array} userChallenges challenges user is participating in
+ */
+export function mapUserWithChallenges(userId, challenges, userChallenges) {
+  if (userChallenges) {
+    const map = {};
+    userChallenges.forEach((item) => { map[item.id] = item; });
+    challenges.forEach((item) => {
+      if (map[item.id]) {
+        /* eslint-disable no-param-reassign */
+        item.users[userId] = true;
+        item.userDetails = map[item.id].userDetails;
+        /* eslint-enable no-param-reassign */
+      }
+    });
+  }
+  return challenges;
+}


### PR DESCRIPTION
Drop out the old `resource-api` call to get user challenges.
Use `GET /challenges?memberId=<userId>&status=Active` instead.
Add `challenge.users[userId]` property for user challenges.
Remove `userChallenges` array from filter, use `challenge.users[userId]` instead.

Addresses topcoder-platform/community-app#4782