### PR TITLE
refactor(challenge-detail): remove `finalSubmissionGuidelines` usages

### DIFF
--- a/src/shared/components/ReviewOpportunityDetailsPage/ChallengeSpecTab/index.jsx
+++ b/src/shared/components/ReviewOpportunityDetailsPage/ChallengeSpecTab/index.jsx
@@ -29,24 +29,6 @@ const ChallengeSpecTab = ({ challenge }) => (
       </article>
       )
     }
-    {
-      challenge.finalSubmissionGuidelines
-      && (
-      <article>
-        <h2 styleName="h2">
-          Final Submission Guidelines
-        </h2>
-        <div
-          /* eslint-disable react/no-danger */
-          dangerouslySetInnerHTML={{
-            __html: challenge.finalSubmissionGuidelines,
-          }}
-          /* eslint-enable react/no-danger */
-          styleName="rawHtml"
-        />
-      </article>
-      )
-    }
   </div>
 );
 

--- a/src/shared/components/challenge-detail/Specification/index.jsx
+++ b/src/shared/components/challenge-detail/Specification/index.jsx
@@ -45,7 +45,6 @@ export default function ChallengeDetailsView(props) {
     legacy,
     legacyId,
     documents,
-    finalSubmissionGuidelines,
     userDetails,
     metadata,
     events,
@@ -190,35 +189,6 @@ export default function ChallengeDetailsView(props) {
                             <SpecificationComponent
                               bodyText={description}
                               format={descriptionFormat}
-                            />
-                          )
-                        }
-                      </article>
-                      )
-                    }
-                    {
-                      finalSubmissionGuidelines
-                      && (
-                      <article>
-                        <h2>
-                          Final Submission Guidelines
-                        </h2>
-                        {
-                          editMode ? (
-                            <Editor
-                              connector={toolbarConnector}
-                              id="submissionGuidelines"
-                              initialMode={EDITOR_MODES.WYSIWYG}
-                              ref={n => n && n.setHtml(finalSubmissionGuidelines)}
-                            />
-                          ) : (
-                            <div
-                              /* eslint-disable react/no-danger */
-                              dangerouslySetInnerHTML={{
-                                __html: finalSubmissionGuidelines,
-                              }}
-                              /* eslint-enable react/no-danger */
-                              styleName="rawHtml"
                             />
                           )
                         }
@@ -408,7 +378,6 @@ ChallengeDetailsView.defaultProps = {
     track: 'design',
     reviewType: undefined,
     numberOfCheckpointsPrizes: 0,
-    finalSubmissionGuidelines: '',
     environment: '',
     descriptionFormat: 'HTML',
     codeRepo: '',
@@ -438,7 +407,6 @@ ChallengeDetailsView.propTypes = {
     groups: PT.any,
     reviewType: PT.string,
     numberOfCheckpointsPrizes: PT.number,
-    finalSubmissionGuidelines: PT.string,
     environment: PT.string,
     codeRepo: PT.string,
     userDetails: PT.shape({


### PR DESCRIPTION
Remove unnecessary `finalSubmissionGuidelines` (it's no longer in use) usages from
`challenge-detail/Specification` and `ReviewOpportunityDetailsPage/ChallengeSpecTab` components.