### PR TITLE
fix(challenge-detail): condition for showing thrive articles 

### DIFF
--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -244,7 +244,7 @@ class ChallengeDetailPageContainer extends React.Component {
     }
 
     const { track } = nextProps.challenge;
-    if (track === COMPETITION_TRACKS.DESIGN && thriveArticles.length === 0) {
+    if (track !== COMPETITION_TRACKS.DESIGN && thriveArticles.length === 0) {
       // filter all tags with value 'Other'
       const tags = _.filter(nextProps.challenge.tags, tag => tag !== 'Other');
       if (tags.length > 0) {


### PR DESCRIPTION
Fix a typo in if condition used to show thrive articles.
  - It was showing them only for the Design track.
  - Articles will be shown for all tracks except for the Design track.

References #4765