### PR TITLE
fix(profile-page): wrong MM url at history graph

### DIFF
--- a/src/shared/components/ProfilePage/Stats/HistoryGraph/index.jsx
+++ b/src/shared/components/ProfilePage/Stats/HistoryGraph/index.jsx
@@ -211,7 +211,7 @@ export default class HistoryGraph extends React.Component {
       }
       if (track === 'DATA_SCIENCE') {
         if (subTrack === 'MARATHON_MATCH') {
-          return `/challenges/${challengeId}`;
+          return `${config.URL.COMMUNITY}/tc?module=MatchDetails&rd=${challengeId}`;
         }
         if (subTrack === 'SRM') {
           return `${config.URL.COMMUNITY}/stat?c=round_overview&rd=${challengeId}`;


### PR DESCRIPTION
Fix wrong MM URLs at `ProfilePage/Stats/HistoryGraph`
  - Old (wrong) URL: `/challenges/<challengeId>`
  - New (correct) URL: `${config.URL.COMMUNITY}/tc?module=MatchDetails&rd=<challengeId>`

Ref #4760 