### PR TITLE
fix(challenge-listing): date filters will use correct query params

### DIFF
--- a/src/shared/components/challenge-listing/Filters/ChallengeFilters.jsx
+++ b/src/shared/components/challenge-listing/Filters/ChallengeFilters.jsx
@@ -47,7 +47,9 @@ export default function ChallengeFilters({
   if (filterState.groups && filterState.groups.length) filterRulesCount += 1;
   if (filterState.tags && filterState.tags.length) filterRulesCount += 1;
   if (filterState.types && filterState.types.length) filterRulesCount += 1;
-  if (filterState.endDateEnd || filterState.startDateStart) filterRulesCount += 1;
+  if (filterState.endDateStart || filterState.startDateEnd) {
+    filterRulesCount += 1;
+  }
   if (isReviewOpportunitiesBucket && filterState.reviewOpportunityType) filterRulesCount += 1;
   if (selectedCommunityId !== '' && selectedCommunityId !== 'All') filterRulesCount += 1;
   const isTrackOn = track => filterState.tracks[track];

--- a/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
+++ b/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
@@ -311,14 +311,21 @@ export default function FiltersPanel({
             </label>
             <DateRangePicker
               numberOfMonths={1}
-              endDate={filterState.endDateEnd && moment(filterState.endDateEnd)}
+              endDate={filterState.startDateEnd && moment(filterState.startDateEnd)}
               id="date-range-picker-one-month"
               onDatesChange={(dates) => {
                 const d = dates.endDate ? dates.endDate.toISOString() : null;
                 const s = dates.startDate ? dates.startDate.toISOString() : null;
-                setFilterState({ ..._.clone(filterState), startDateStart: s, endDateEnd: d });
+                setFilterState({
+                  ..._.clone(filterState),
+                  endDateStart: s,
+                  startDateEnd: d,
+                });
               }}
-              startDate={filterState.startDateStart && moment(filterState.startDateStart)}
+              startDate={
+                filterState.endDateStart
+                  && moment(filterState.endDateStart)
+              }
             />
           </div>
           <div styleName="filter dates hideonemonthdatepicker">
@@ -328,15 +335,20 @@ export default function FiltersPanel({
             </label>
             <DateRangePicker
               numberOfMonths={2}
-              endDate={filterState.endDateEnd && moment(filterState.endDateEnd)}
+              endDate={filterState.startDateEnd && moment(filterState.startDateEnd)}
               id="date-range-picker-two-months"
               onDatesChange={(dates) => {
                 const d = dates.endDate ? dates.endDate.toISOString() : null;
                 const s = dates.startDate ? dates.startDate.toISOString() : null;
-                setFilterState({ ..._.clone(filterState), startDateStart: s, endDateEnd: d });
+                setFilterState({
+                  ..._.clone(filterState),
+                  endDateStart: s,
+                  startDateEnd: d,
+                });
               }}
               startDate={
-                filterState.startDateStart && moment(filterState.startDateStart)
+                filterState.endDateStart
+                  && moment(filterState.endDateStart)
               }
             />
           </div>
@@ -358,8 +370,8 @@ export default function FiltersPanel({
               tags: [],
               types: [],
               groups: [],
-              startDateStart: null,
-              endDateEnd: null,
+              endDateStart: null,
+              startDateEnd: null,
             });
             selectCommunity(defaultCommunityId);
             setSearchText('');

--- a/src/shared/reducers/challenge-listing/index.js
+++ b/src/shared/reducers/challenge-listing/index.js
@@ -401,7 +401,7 @@ function onSetFilter(state, { payload }) {
    * do it very carefuly (many params are not validated). */
   const filter = _.pickBy(_.pick(
     payload,
-    ['tags', 'types', 'name', 'startDateStart', 'endDateEnd', 'groups'],
+    ['tags', 'types', 'name', 'startDateEnd', 'endDateStart', 'groups'],
   ), value => (!_.isArray(value) && value && value !== '') || (_.isArray(value) && value.length > 0));
   // if (_.isPlainObject(filter.tags)) {
   //   filter.tags = _.values(filter.tags);
@@ -409,11 +409,11 @@ function onSetFilter(state, { payload }) {
   // if (_.isPlainObject(filter.subtracks)) {
   //   filter.subtracks = _.values(filter.subtracks);
   // }
-  if (filter.startDateStart && !moment(filter.startDateStart).isValid()) {
-    delete filter.startDateStart;
+  if (filter.startDateEnd && !moment(filter.startDateEnd).isValid()) {
+    delete filter.startDateEnd;
   }
-  if (filter.endDateEnd && !moment(filter.endDateEnd).isValid()) {
-    delete filter.endDateEnd;
+  if (filter.endDateStart && !moment(filter.endDateStart).isValid()) {
+    delete filter.endDateStart;
   }
   // console.log(`aaaaa`);
   // console.log(filter);
@@ -810,8 +810,8 @@ function create(initialState) {
       tags: [],
       types: [],
       groups: [],
-      startDateStart: null,
-      endDateEnd: null,
+      startDateEnd: null,
+      endDateStart: null,
     },
 
     selectedCommunityId: 'All',

--- a/src/shared/utils/challenge-listing/buckets.js
+++ b/src/shared/utils/challenge-listing/buckets.js
@@ -172,8 +172,8 @@ export function filterChanged(filter, prevFilter) {
   || (filter.tracks.DS !== prevFilter.tracks.DS)
   || (filter.tracks.QA !== prevFilter.tracks.QA)
   || (filter.name !== prevFilter.name)
-  || (filter.startDateStart !== prevFilter.startDateStart)
-  || (filter.endDateEnd !== prevFilter.endDateEnd)
+  || (filter.startDateEnd !== prevFilter.startDateEnd)
+  || (filter.endDateStart !== prevFilter.endDateStart)
   // eslint-disable-next-line max-len
   || (filter.groups.length !== prevFilter.groups.length || filter.groups[0] !== prevFilter.groups[0])
   || _.filter(filter.tags, val => _.indexOf(prevFilter.tags, val) < 0).length > 0


### PR DESCRIPTION
* The date filters at challenge listing page was using
`startDateStart` (start date) and `endDateEnd` (end date)
query parameters for `GET /challenges` call.
* It now uses `startDateEnd` (end date) and `endDateStart` (start date)
instead, in  compliance with previous implementation.

Addresses #4984