### PR TITLE
Filter update -- fix issue 5068's comments

### DIFF
--- a/__tests__/shared/components/challenge-listing/__snapshots__/index.jsx.snap
+++ b/__tests__/shared/components/challenge-listing/__snapshots__/index.jsx.snap
@@ -24,18 +24,6 @@ exports[`Matches shallow shapshot 1 shapshot 1 1`] = `
         setFilterState={[MockFunction]}
       />
     </div>
-    <div
-      className="src-shared-components-challenge-listing-___style__sidebar-container-desktop___h0bz6"
-    >
-      <Connect(SidebarContainer)
-        expanding={false}
-      />
-      <Connect(Container)
-        communityName={null}
-        isAuth={false}
-        setFilterState={[MockFunction]}
-      />
-    </div>
     <Connect(Listing)
       activeBucket="abc"
       auth={Object {}}
@@ -80,19 +68,6 @@ exports[`Matches shallow shapshot 2 shapshot 2 1`] = `
     className="src-shared-components-challenge-listing-___style__tc-content-wrapper___1MqlF"
   >
     <div
-      className="src-shared-components-challenge-listing-___style__sidebar-container-mobile___3e65d"
-    >
-      <Connect(SidebarContainer)
-        expanding={false}
-      />
-      <Connect(Container)
-        communityName={null}
-        hidden={true}
-        isAuth={false}
-        setFilterState={[MockFunction]}
-      />
-    </div>
-    <div
       className="src-shared-components-challenge-listing-___style__sidebar-container-desktop___h0bz6"
     >
       <Connect(SidebarContainer)
@@ -100,6 +75,7 @@ exports[`Matches shallow shapshot 2 shapshot 2 1`] = `
       />
       <Connect(Container)
         communityName={null}
+        hidden={false}
         isAuth={false}
         setFilterState={[MockFunction]}
       />

--- a/__tests__/shared/components/challenge-listing/index.jsx
+++ b/__tests__/shared/components/challenge-listing/index.jsx
@@ -43,6 +43,9 @@ describe('Matches shallow shapshot 1', () => {
 describe('Matches shallow shapshot 2', () => {
   beforeEach(() => {
     jest.resetModules();
+    jest.mock('react-responsive', () => ({
+      useMediaQuery: () => true,
+    }));
     ChallengeListing = require('components/challenge-listing').default;
   });
 

--- a/__tests__/shared/reducers/challenge-listing/sidebar.js
+++ b/__tests__/shared/reducers/challenge-listing/sidebar.js
@@ -2,7 +2,6 @@ const defaultReducer = require('reducers/challenge-listing/sidebar').default;
 
 const expectedState = {
   activeBucket: 'openForRegistration',
-  past: false,
 };
 
 function testReducer(reducer) {

--- a/src/shared/actions/challenge-listing/sidebar.js
+++ b/src/shared/actions/challenge-listing/sidebar.js
@@ -153,8 +153,6 @@ export default createActions({
 
       // UPDATE_ALL_SAVED_FILTERS: updateAllSavedFilters,
       // UPDATE_SAVED_FILTER: updateSavedFilter,
-
-      SET_PAST: isPast => ({ past: isPast }),
     },
   },
 });

--- a/src/shared/components/DateRangePicker/index.jsx
+++ b/src/shared/components/DateRangePicker/index.jsx
@@ -466,6 +466,15 @@ function DateRangePicker(props) {
               >
                 Reset
               </button>
+              <button
+                type="button"
+                styleName="close-button"
+                onClick={() => {
+                  setIsComponentVisible(false);
+                }}
+              >
+                &times;
+              </button>
             </div>
           )
         }

--- a/src/shared/components/DateRangePicker/style.scss
+++ b/src/shared/components/DateRangePicker/style.scss
@@ -392,6 +392,24 @@
       margin: 20px 12px 0;
     }
   }
+
+  .close-button {
+    position: absolute;
+    top: 0;
+    right: 0;
+    display: none;
+    line-height: 16px;
+    padding: 15px;
+    font-size: 36px;
+    color: $tc-black;
+    appearance: none;
+    background: none;
+    border: 0;
+
+    @include phone {
+      display: block;
+    }
+  }
 }
 
 .endDate {

--- a/src/shared/components/challenge-detail/Header/ChallengeTags.jsx
+++ b/src/shared/components/challenge-detail/Header/ChallengeTags.jsx
@@ -88,9 +88,9 @@ export default function ChallengeTags(props) {
               && (
               <Tag
                 key={tag}
-                onClick={() => setImmediate(() => setChallengeListingFilter({ tags: [tag] }))
+                onClick={() => setImmediate(() => setChallengeListingFilter({ search: tag }))
                 }
-                to={`${challengesUrl}?tags[]=${
+                to={`${challengesUrl}?search=${
                   encodeURIComponent(tag)}`}
               >
                 {tag}

--- a/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
+++ b/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
@@ -225,8 +225,6 @@ export default function FiltersPanel({
       data: getLabel(community),
     }));
 
-  const disableClearFilterButtons = isFilterEmpty(filterState);
-
   // const mapOps = item => ({ label: item, value: item });
   const mapTypes = item => ({ label: item.name, value: item.abbreviation });
   const getCommunityOption = () => {
@@ -249,6 +247,7 @@ export default function FiltersPanel({
 
   const staticRanges = createStaticRanges();
   const past = isPastBucket(activeBucket);
+  const disableClearFilterButtons = isFilterEmpty(filterState, past ? 'past' : '', activeBucket);
 
   return (
     <div styleName="FiltersPanel">

--- a/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
+++ b/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
@@ -32,7 +32,7 @@ import Tooltip from 'components/Tooltip';
 import { config, Link } from 'topcoder-react-utils';
 import { COMPOSE, PRIORITY } from 'react-css-super-themr';
 import { REVIEW_OPPORTUNITY_TYPES } from 'utils/tc';
-import { isFilterEmpty } from 'utils/challenge-listing/buckets';
+import { isFilterEmpty, isPastBucket } from 'utils/challenge-listing/buckets';
 import SwitchWithLabel from 'components/SwitchWithLabel';
 import { challenge as challengeUtils } from 'topcoder-react-lib';
 import { createStaticRanges } from 'utils/challenge-listing/date-range';
@@ -64,7 +64,6 @@ export default function FiltersPanel({
   // isSavingFilter,
   expanded,
   setExpanded,
-  past,
 }) {
   if (hidden && !expanded) {
     return (
@@ -226,7 +225,7 @@ export default function FiltersPanel({
       data: getLabel(community),
     }));
 
-  const disableClearFilterButtons = isFilterEmpty(filterState, past ? 'past' : '', activeBucket);
+  const disableClearFilterButtons = isFilterEmpty(filterState);
 
   // const mapOps = item => ({ label: item, value: item });
   const mapTypes = item => ({ label: item.name, value: item.abbreviation });
@@ -249,6 +248,7 @@ export default function FiltersPanel({
   };
 
   const staticRanges = createStaticRanges();
+  const past = isPastBucket(activeBucket);
 
   return (
     <div styleName="FiltersPanel">
@@ -495,47 +495,52 @@ export default function FiltersPanel({
           ) : null
         }
 
-        <div styleName="filter-row">
-          <div styleName="filter filter community">
-            <label htmlFor="community-select" styleName="label">
-              Sub community
-              <input type="hidden" />
-            </label>
-            <Select
-              autoBlur
-              clearable={false}
-              id="community-select"
-              // onChange={selectCommunity}
-              onChange={(value) => {
-                if (value && value.startsWith('event_')) {
-                  const event = value.split('_')[1];
-                  setFilterState({
-                    ..._.clone(filterState),
-                    events: event === '' ? [] : [event],
-                    groups: [],
-                  });
-                } else {
-                  const group = value;
-                  setFilterState({
-                    ..._.clone(filterState),
-                    groups: group === '' ? [] : [group],
-                    events: [],
-                  });
-                }
-                // setFilterState({ ..._.clone(filterState), groups: [value] });
-              }}
-              options={communityOps}
-              simpleValue
-              value={getCommunityOption()}
-              valueRenderer={option => (
-                <span styleName="active-community">
-                  {option.name}
-                </span>
-              )}
-            />
-          </div>
-        </div>
+        { !isReviewOpportunitiesBucket
+          && (
+            <div styleName="filter-row">
+              <div styleName="filter filter community">
+                <label htmlFor="community-select" styleName="label">
+                  Sub community
+                  <input type="hidden" />
+                </label>
+                <Select
+                  autoBlur
+                  clearable={false}
+                  id="community-select"
+                  // onChange={selectCommunity}
+                  onChange={(value) => {
+                    if (value && value.startsWith('event_')) {
+                      const event = value.split('_')[1];
+                      setFilterState({
+                        ..._.clone(filterState),
+                        events: event === '' ? [] : [event],
+                        groups: [],
+                      });
+                    } else {
+                      const group = value;
+                      setFilterState({
+                        ..._.clone(filterState),
+                        groups: group === '' ? [] : [group],
+                        events: [],
+                      });
+                    }
+                    // setFilterState({ ..._.clone(filterState), groups: [value] });
+                  }}
+                  options={communityOps}
+                  simpleValue
+                  value={getCommunityOption()}
+                  valueRenderer={option => (
+                    <span styleName="active-community">
+                      {option.name}
+                    </span>
+                  )}
+                />
+              </div>
+            </div>
+          )
+        }
       </div>
+
       <div styleName="buttons">
         <Button
           composeContextTheme={COMPOSE.SOFT}
@@ -607,5 +612,4 @@ FiltersPanel.propTypes = {
   onClose: PT.func,
   expanded: PT.bool.isRequired,
   setExpanded: PT.func.isRequired,
-  past: PT.bool.isRequired,
 };

--- a/src/shared/components/challenge-listing/Filters/FiltersPanel/style.scss
+++ b/src/shared/components/challenge-listing/Filters/FiltersPanel/style.scss
@@ -119,8 +119,8 @@
       display: block;
       color: $tc-black;
       font-size: 11px;
-      line-height: 13px;
-      margin-bottom: 4px;
+      line-height: 15px;
+      margin-bottom: 8px;
     }
 
     @include xs-to-md {

--- a/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
@@ -125,7 +125,13 @@ export default function Bucket({
       challengeType={_.find(challengeTypes, { name: challenge.type })}
       challengesUrl={challengesUrl}
       newChallengeDetails={newChallengeDetails}
-      onTechTagClicked={tag => setFilterState({ ..._.clone(filterState), tags: [tag], types: [] })}
+      onTechTagClicked={(tag) => {
+        setFilterState({
+          ..._.clone(filterState),
+          tags: [tag],
+          types: challengeTypes.map(type => type.abbreviation),
+        });
+      }}
       openChallengesInNewTabs={openChallengesInNewTabs}
       prizeMode={prizeMode}
       key={challenge.id}

--- a/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
@@ -49,6 +49,7 @@ export default function Bucket({
   activeBucket,
   // searchTimestamp,
   isLoggedIn,
+  setSearchText,
 }) {
   const refs = useRef([]);
   refs.current = [];
@@ -128,9 +129,10 @@ export default function Bucket({
       onTechTagClicked={(tag) => {
         setFilterState({
           ..._.clone(filterState),
-          tags: [tag],
+          search: tag,
           types: challengeTypes.map(type => type.abbreviation),
         });
+        setSearchText(tag);
       }}
       openChallengesInNewTabs={openChallengesInNewTabs}
       prizeMode={prizeMode}
@@ -256,4 +258,5 @@ Bucket.propTypes = {
   activeBucket: PT.string,
   // searchTimestamp: PT.number,
   isLoggedIn: PT.bool.isRequired,
+  setSearchText: PT.func.isRequired,
 };

--- a/src/shared/components/challenge-listing/Listing/ReviewOpportunityBucket/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/ReviewOpportunityBucket/index.jsx
@@ -33,6 +33,7 @@ export default function ReviewOpportunityBucket({
   setSort,
   challengeTypes,
   sort,
+  setSearchText,
 }) {
   if (!opportunities.length && !loadMore) return null;
 
@@ -59,7 +60,10 @@ export default function ReviewOpportunityBucket({
       challengeType={_.find(challengeTypes, { name: item.challenge.type }) || {}}
       expandedTags={expandedTags}
       expandTag={expandTag}
-      onTechTagClicked={tag => setFilterState({ tags: [tag] })}
+      onTechTagClicked={(tag) => {
+        setFilterState({ search: tag });
+        setSearchText(tag);
+      }}
       opportunity={item}
       key={item.id}
     />
@@ -132,4 +136,5 @@ ReviewOpportunityBucket.propTypes = {
   setSort: PT.func.isRequired,
   sort: PT.string,
   challengeTypes: PT.arrayOf(PT.shape()).isRequired,
+  setSearchText: PT.func.isRequired,
 };

--- a/src/shared/components/challenge-listing/Listing/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/index.jsx
@@ -71,6 +71,7 @@ function Listing({
   // pastSearchTimestamp,
   isLoggedIn,
   meta,
+  setSearchText,
 }) {
   // const buckets = getBuckets(userChallenges);
   // const isChallengesAvailable = (bucket) => {
@@ -159,6 +160,7 @@ function Listing({
             sort={sorts[bucket]}
             challengeTypes={challengeTypes}
             isLoggedIn={isLoggedIn}
+            setSearchText={setSearchText}
           />
         )
         : (
@@ -194,6 +196,7 @@ function Listing({
             activeBucket={activeBucket}
             // searchTimestamp={searchTimestamp}
             isLoggedIn={isLoggedIn}
+            setSearchText={setSearchText}
           />
         )
     );
@@ -348,6 +351,7 @@ Listing.propTypes = {
   // userChallenges: PT.arrayOf(PT.string),
   isLoggedIn: PT.bool.isRequired,
   meta: PT.shape().isRequired,
+  setSearchText: PT.func.isRequired,
 };
 
 const mapStateToProps = (state) => {

--- a/src/shared/components/challenge-listing/Sidebar/index.jsx
+++ b/src/shared/components/challenge-listing/Sidebar/index.jsx
@@ -18,7 +18,7 @@
 import React from 'react';
 import PT from 'prop-types';
 // import _ from 'lodash';
-import { BUCKETS } from 'utils/challenge-listing/buckets';
+import { BUCKETS, isPastBucket } from 'utils/challenge-listing/buckets';
 import BucketSelector from './BucketSelector';
 // import FiltersEditor from './FiltersEditor';
 // import Footer from './Footer';
@@ -50,19 +50,18 @@ export default function SideBarFilters({
   // updateAllSavedFilters,
   // updateSavedFilter,
   // setFilter,
-  past,
-  setPast,
   previousBucketOfActiveTab,
   previousBucketOfPastChallengesTab,
   setPreviousBucketOfActiveTab,
   setPreviousBucketOfPastChallengesTab,
 }) {
+  const past = isPastBucket(activeBucket);
+
   const onActiveClick = () => {
     if (!past) {
       return;
     }
     setPreviousBucketOfPastChallengesTab(activeBucket);
-    setPast(false);
     if (previousBucketOfActiveTab) {
       selectBucket(previousBucketOfActiveTab);
     } else {
@@ -75,7 +74,6 @@ export default function SideBarFilters({
       return;
     }
     setPreviousBucketOfActiveTab(activeBucket);
-    setPast(true);
     if (previousBucketOfPastChallengesTab) {
       selectBucket(previousBucketOfPastChallengesTab);
     } else {
@@ -193,8 +191,6 @@ SideBarFilters.propTypes = {
   // updateAllSavedFilters: PT.func.isRequired,
   // updateSavedFilter: PT.func.isRequired,
   // setFilter: PT.func.isRequired,
-  past: PT.bool.isRequired,
-  setPast: PT.func.isRequired,
   previousBucketOfActiveTab: PT.string,
   previousBucketOfPastChallengesTab: PT.string,
   setPreviousBucketOfActiveTab: PT.func,

--- a/src/shared/components/challenge-listing/index.jsx
+++ b/src/shared/components/challenge-listing/index.jsx
@@ -13,6 +13,7 @@ import PT from 'prop-types';
 import Sidebar from 'containers/challenge-listing/Sidebar';
 // import { isReviewOpportunitiesBucket } from 'utils/challenge-listing/buckets';
 // import { config } from 'topcoder-react-utils';
+import { useMediaQuery } from 'react-responsive';
 
 import Listing from './Listing';
 // import ChallengeCardPlaceholder from './placeholders/ChallengeCard';
@@ -147,6 +148,8 @@ export default function ChallengeListing(props) {
   );
   // }
 
+  const desktop = useMediaQuery({ minWidth: 1024 });
+
   return (
     <div styleName="ChallengeFiltersExample" id="challengeFilterContainer">
       <ChallengeSearchBar
@@ -154,7 +157,7 @@ export default function ChallengeListing(props) {
       />
 
       <div styleName="tc-content-wrapper">
-        <div styleName="sidebar-container-mobile">
+        <div styleName={desktop ? 'sidebar-container-desktop' : 'sidebar-container-mobile'}>
           <Sidebar
             expanding={expanding}
           />
@@ -165,23 +168,8 @@ export default function ChallengeListing(props) {
             hideSrm={hideSrm}
             isAuth={Boolean(auth.user)}
             setFilterState={props.setFilterState}
-            hidden
+            hidden={!desktop}
           />
-        </div>
-
-        <div styleName="sidebar-container-desktop">
-          <Sidebar
-            expanding={expanding}
-          />
-
-          <FilterPanel
-            communityName={communityName}
-            defaultCommunityId={defaultCommunityId}
-            hideSrm={hideSrm}
-            isAuth={Boolean(auth.user)}
-            setFilterState={props.setFilterState}
-          />
-
         </div>
 
         {challengeCardContainer}

--- a/src/shared/components/challenge-listing/index.jsx
+++ b/src/shared/components/challenge-listing/index.jsx
@@ -49,6 +49,7 @@ export default function ChallengeListing(props) {
     // isBucketSwitching,
     isLoggedIn,
     meta,
+    setSearchText,
   } = props;
 
   // const { challenges } = props;
@@ -144,6 +145,7 @@ export default function ChallengeListing(props) {
       // userChallenges={props.userChallenges}
       isLoggedIn={isLoggedIn}
       meta={meta}
+      setSearchText={setSearchText}
     />
   );
   // }
@@ -258,4 +260,5 @@ ChallengeListing.propTypes = {
   // userChallenges: PT.arrayOf(PT.string),
   isLoggedIn: PT.bool.isRequired,
   meta: PT.shape().isRequired,
+  setSearchText: PT.func.isRequired,
 };

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -14,6 +14,7 @@ import pageActions from 'actions/page';
 import ChallengeHeader from 'components/challenge-detail/Header';
 import challengeListingActions from 'actions/challenge-listing';
 import challengeListingSidebarActions from 'actions/challenge-listing/sidebar';
+import challengeListingFilterPanelActions from 'actions/challenge-listing/filter-panel';
 import Registrants from 'components/challenge-detail/Registrants';
 import shortId from 'shortid';
 import Submissions from 'components/challenge-detail/Submissions';
@@ -880,13 +881,15 @@ const mapDispatchToProps = (dispatch) => {
     setChallengeListingFilter: (filter, stateProps) => {
       const cl = challengeListingActions.challengeListing;
       const cls = challengeListingSidebarActions.challengeListing.sidebar;
+      const fp = challengeListingFilterPanelActions.challengeListing.filterPanel;
       const newFilter = _.assign(
         {},
-        { types: stateProps.challengeTypesMap.map(type => type.abbreviation), tags: [] },
+        { types: stateProps.challengeTypes.map(type => type.abbreviation), search: '' },
         filter,
       );
       dispatch(cls.selectBucket(BUCKETS.OPEN_FOR_REGISTRATION));
       dispatch(cl.setFilter(newFilter));
+      dispatch(fp.setSearchText(newFilter.search));
     },
     setSpecsTabState: state => dispatch(pageActions.page.challengeDetails.setSpecsTabState(state)),
     unregisterFromChallenge: (auth, challengeId) => {

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -877,10 +877,14 @@ const mapDispatchToProps = (dispatch) => {
           return challengeDetails;
         });
     },
-    setChallengeListingFilter: (filter) => {
+    setChallengeListingFilter: (filter, stateProps) => {
       const cl = challengeListingActions.challengeListing;
       const cls = challengeListingSidebarActions.challengeListing.sidebar;
-      const newFilter = _.assign({}, { types: [], tags: [] }, filter);
+      const newFilter = _.assign(
+        {},
+        { types: stateProps.challengeTypesMap.map(type => type.abbreviation), tags: [] },
+        filter,
+      );
       dispatch(cls.selectBucket(BUCKETS.OPEN_FOR_REGISTRATION));
       dispatch(cl.setFilter(newFilter));
     },
@@ -943,9 +947,17 @@ const mapDispatchToProps = (dispatch) => {
   };
 };
 
+const mergeProps = (stateProps, dispatchProps, ownProps) => ({
+  ...ownProps,
+  ...stateProps,
+  ...dispatchProps,
+  setChallengeListingFilter: filter => dispatchProps.setChallengeListingFilter(filter, stateProps),
+});
+
 const ChallengeDetailContainer = connect(
   mapStateToProps,
   mapDispatchToProps,
+  mergeProps,
 )(ChallengeDetailPageContainer);
 
 export default ChallengeDetailContainer;

--- a/src/shared/containers/challenge-listing/Listing/index.jsx
+++ b/src/shared/containers/challenge-listing/Listing/index.jsx
@@ -21,6 +21,7 @@ import { connect } from 'react-redux';
 import ChallengeListing from 'components/challenge-listing';
 import Banner from 'components/tc-communities/Banner';
 import sidebarActions from 'actions/challenge-listing/sidebar';
+import filterPanelActions from 'actions/challenge-listing/filter-panel';
 import communityActions from 'actions/tc-communities';
 // import SORT from 'utils/challenge-listing/sort';
 import { BUCKETS, filterChanged, sortChangedBucket } from 'utils/challenge-listing/buckets';
@@ -447,6 +448,7 @@ export class ListingContainer extends React.Component {
       // isBucketSwitching,
       // userChallenges,
       meta,
+      setSearchText,
     } = this.props;
 
     const { tokenV3 } = auth;
@@ -617,6 +619,7 @@ export class ListingContainer extends React.Component {
           // userChallenges={[]}
           isLoggedIn={isLoggedIn}
           meta={meta}
+          setSearchText={setSearchText}
         />
       </div>
     );
@@ -741,6 +744,7 @@ ListingContainer.propTypes = {
   getTotalChallengesCount: PT.func.isRequired,
   // userChallenges: PT.arrayOf(PT.string),
   // getUserChallenges: PT.func.isRequired,
+  setSearchText: PT.func.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -807,6 +811,7 @@ function mapDispatchToProps(dispatch) {
   const a = actions.challengeListing;
   const ah = headerActions.topcoderHeader;
   const sa = sidebarActions.challengeListing.sidebar;
+  const fp = filterPanelActions.challengeListing.filterPanel;
   const ca = communityActions.tcCommunity;
   return {
     dropChallenges: () => dispatch(a.dropChallenges()),
@@ -880,6 +885,7 @@ function mapDispatchToProps(dispatch) {
     //   dispatch(a.getUserChallengesInit(uuid));
     //   dispatch(a.getUserChallengesDone(userId, tokenV3));
     // },
+    setSearchText: text => dispatch(fp.setSearchText(text)),
   };
 }
 

--- a/src/shared/containers/challenge-listing/Listing/index.jsx
+++ b/src/shared/containers/challenge-listing/Listing/index.jsx
@@ -37,11 +37,6 @@ const { mapToBackend } = challengeUtils.filter;
 let mounted = false;
 
 export class ListingContainer extends React.Component {
-  constructor(props) {
-    super(props);
-    this.firstReload = false;
-  }
-
   componentDidMount() {
     const {
       activeBucket,
@@ -118,7 +113,6 @@ export class ListingContainer extends React.Component {
       dropOpenForRegistrationChallenges,
       dropPastChallenges,
       getPastChallenges,
-      past,
     } = this.props;
     const oldUserId = _.get(prevProps, 'auth.user.userId');
     const userId = _.get(this.props, 'auth.user.userId');
@@ -224,19 +218,7 @@ export class ListingContainer extends React.Component {
       }
       return;
     }
-    let reload;
-    if (!this.firstReload) {
-      reload = true;
-      this.firstReload = true;
-    } else if (prevProps.past === past) {
-      reload = past
-        ? filterChanged(filter, prevProps.filter)
-        : filterChanged(
-          _.omit(filter, 'startDateEnd', 'endDateStart'),
-          _.omit(prevProps.filter, 'startDateEnd', 'endDateStart'),
-        );
-    }
-    if (reload) {
+    if (filterChanged(filter, prevProps.filter)) {
       this.reloadChallenges();
     }
     setTimeout(() => {
@@ -263,8 +245,7 @@ export class ListingContainer extends React.Component {
       sorts,
       filter,
     } = this.props;
-    const filterTemp = _.omit(filter, 'reviewOpportunityTypes', 'customDate',
-      'previousStartDate', 'previousEndDate');
+    const filterTemp = _.omit(filter, 'reviewOpportunityTypes', 'customDate');
     // let communityFilter = communitiesList.data.find(
     // item => item.communityId === selectedCommunityId,
     // );
@@ -760,7 +741,6 @@ ListingContainer.propTypes = {
   getTotalChallengesCount: PT.func.isRequired,
   // userChallenges: PT.arrayOf(PT.string),
   // getUserChallenges: PT.func.isRequired,
-  past: PT.bool.isRequired,
 };
 
 const mapStateToProps = (state, ownProps) => {
@@ -820,7 +800,6 @@ const mapStateToProps = (state, ownProps) => {
     expandedTags: cl.expandedTags,
     meta: cl.meta,
     // userChallenges: cl.userChallenges,
-    past: cl.sidebar.past,
   };
 };
 

--- a/src/shared/containers/challenge-listing/Sidebar.jsx
+++ b/src/shared/containers/challenge-listing/Sidebar.jsx
@@ -55,7 +55,7 @@ export class SidebarContainer extends React.Component {
   }
 
   render() {
-    const {
+    // const {
     // activeBucket,
     // communityFilters,
     // deleteSavedFilter,
@@ -69,9 +69,7 @@ export class SidebarContainer extends React.Component {
     // updateAllSavedFilters,
     // updateSavedFilter,
     // userChallenges,
-      past,
-      setPast,
-    } = this.props;
+    // } = this.props;
 
     const {
       previousBucketOfActiveTab,
@@ -128,8 +126,6 @@ export class SidebarContainer extends React.Component {
         setPreviousBucketOfPastChallengesTab={(bucket) => {
           this.setState({ previousBucketOfPastChallengesTab: bucket });
         }}
-        past={past}
-        setPast={setPast}
       />
     );
   }
@@ -164,8 +160,6 @@ SidebarContainer.propTypes = {
   // user: PT.shape(),
   // userChallenges: PT.arrayOf(PT.string),
   expanding: PT.bool,
-  past: PT.bool.isRequired,
-  setPast: PT.func.isRequired,
 };
 
 function mapDispatchToProps(dispatch) {
@@ -201,7 +195,6 @@ function mapStateToProps(state) {
     // user: state.auth.user,
     // userChallenges: state.challengeListing.userChallenges,
     expanding: sb.expanding,
-    past: sb.past,
   };
 }
 

--- a/src/shared/reducers/challenge-listing/index.js
+++ b/src/shared/reducers/challenge-listing/index.js
@@ -907,7 +907,7 @@ function create(initialState) {
         DS: true,
         QA: true,
       },
-      name: '',
+      search: '',
       tags: [],
       types: [],
       groups: [],

--- a/src/shared/reducers/challenge-listing/sidebar.js
+++ b/src/shared/reducers/challenge-listing/sidebar.js
@@ -175,15 +175,6 @@ function onSelectBucketDone(state) {
 //   return { ...state, savedFilters };
 // }
 
-function onSetPast(state, { payload }) {
-  const { past } = payload;
-
-  return {
-    ...state,
-    past,
-  };
-}
-
 function create(initialState = {}) {
   const a = actions.challengeListing.sidebar;
   return handleActions({
@@ -209,14 +200,12 @@ function create(initialState = {}) {
     //   editSavedFiltersMode: payload,
     // }),
     // [a.updateSavedFilter]: onUpdateSavedFilter,
-    [a.setPast]: onSetPast,
   }, _.defaults(initialState, {
     activeBucket: BUCKETS.OPEN_FOR_REGISTRATION,
     // activeSavedFilter: 0,
     // editSavedFiltersMode: false,
     // savedFilters: [],
     // isSavingFilter: false,
-    past: false,
   }));
 }
 

--- a/src/shared/utils/challenge-listing/buckets.js
+++ b/src/shared/utils/challenge-listing/buckets.js
@@ -211,51 +211,27 @@ export function sortChangedBucket(sorts, prevSorts) {
   return '';
 }
 
-export function isFilterEmpty(filter, tab, bucket) {
-  let f;
-  let empty;
-
-  if (tab === 'past') {
-    f = _.pick(filter, 'tracks', 'search', 'types', 'startDateEnd', 'endDateStart');
-    empty = {
-      tracks: {
-        Dev: true,
-        Des: true,
-        DS: true,
-        QA: true,
-      },
-      search: '',
-      types: ['CH', 'F2F', 'TSK'],
-      startDateEnd: null,
-      endDateStart: null,
-    };
-  } else if (bucket === BUCKETS.REVIEW_OPPORTUNITIES) {
-    f = _.pick(filter, 'tracks', 'search', 'reviewOpportunityTypes');
-    empty = {
-      tracks: {
-        Dev: true,
-        Des: true,
-        DS: true,
-        QA: true,
-      },
-      search: '',
-      reviewOpportunityTypes: _.keys(REVIEW_OPPORTUNITY_TYPES),
-    };
-  } else {
-    f = _.pick(filter, 'tracks', 'search', 'types');
-    empty = {
-      tracks: {
-        Dev: true,
-        Des: true,
-        DS: true,
-        QA: true,
-      },
-      search: '',
-      types: ['CH', 'F2F', 'TSK'],
-    };
-  }
+export function isFilterEmpty(filter) {
+  const f = _.pick(filter, 'tracks', 'search', 'types', 'startDateEnd', 'endDateStart', 'reviewOpportunityTypes');
+  const empty = {
+    tracks: {
+      Dev: true,
+      Des: true,
+      DS: true,
+      QA: true,
+    },
+    search: '',
+    types: ['CH', 'F2F', 'TSK'],
+    startDateEnd: null,
+    endDateStart: null,
+    reviewOpportunityTypes: _.keys(REVIEW_OPPORTUNITY_TYPES),
+  };
 
   return _.isEqual(f, empty);
+}
+
+export function isPastBucket(bucket) {
+  return [BUCKETS.ALL_PAST, BUCKETS.MY_PAST].indexOf(bucket) !== -1;
 }
 
 export default undefined;

--- a/src/shared/utils/challenge-listing/buckets.js
+++ b/src/shared/utils/challenge-listing/buckets.js
@@ -211,21 +211,51 @@ export function sortChangedBucket(sorts, prevSorts) {
   return '';
 }
 
-export function isFilterEmpty(filter) {
-  const f = _.pick(filter, 'tracks', 'search', 'types', 'startDateEnd', 'endDateStart', 'reviewOpportunityTypes');
-  const empty = {
-    tracks: {
-      Dev: true,
-      Des: true,
-      DS: true,
-      QA: true,
-    },
-    search: '',
-    types: ['CH', 'F2F', 'TSK'],
-    startDateEnd: null,
-    endDateStart: null,
-    reviewOpportunityTypes: _.keys(REVIEW_OPPORTUNITY_TYPES),
-  };
+export function isFilterEmpty(filter, tab, bucket) {
+  let f;
+  let empty;
+
+  if (tab === 'past') {
+    f = _.pick(filter, 'tracks', 'search', 'types', 'startDateEnd', 'endDateStart');
+    if (f.types) f.types = [...f.types].sort();
+    empty = {
+      tracks: {
+        Dev: true,
+        Des: true,
+        DS: true,
+        QA: true,
+      },
+      search: '',
+      types: ['CH', 'F2F', 'TSK'],
+      startDateEnd: null,
+      endDateStart: null,
+    };
+  } else if (bucket === BUCKETS.REVIEW_OPPORTUNITIES) {
+    f = _.pick(filter, 'tracks', 'search', 'reviewOpportunityTypes');
+    empty = {
+      tracks: {
+        Dev: true,
+        Des: true,
+        DS: true,
+        QA: true,
+      },
+      search: '',
+      reviewOpportunityTypes: _.keys(REVIEW_OPPORTUNITY_TYPES),
+    };
+  } else {
+    f = _.pick(filter, 'tracks', 'search', 'types');
+    if (f.types) f.types = [...f.types].sort();
+    empty = {
+      tracks: {
+        Dev: true,
+        Des: true,
+        DS: true,
+        QA: true,
+      },
+      search: '',
+      types: ['CH', 'F2F', 'TSK'],
+    };
+  }
 
   return _.isEqual(f, empty);
 }


### PR DESCRIPTION
**issuecomment-741596441**:  _(1) intentional_, _(2) fixed_: layout issue, _(3) fixed_: after coming back from the challenge details, the default tab is 'Active' and default bucket is 'Open for registration'
**issuecomment-741600474**: _fixed_: layout issue
**issuecomment-741904592**: _fixed_: forgot to set the challenge 'types' filter to all when clicking on the challenge Tags

&nbsp;

About 741904592:  `search=<tag>` vs `tags[]=<tag>`
- There are modules of the community-app allowing to search by multiple tags (ex: Contentful EDU search) while `search=<tag>`  is allowing searching by a single tag only
- `search=<tag>` searching in challenges' name, description and tags, so there is a confused case that a challenge with only HTML tag but its description including the keyword 'Java' still being listed when user clicking on the 'Java' tag under the header of some challenge details.

So I think `tags[]=<tag>` is better than `search=<tag>` and its search results will be the same as the results of the old filter panel.