### PR TITLE
issue #5501 fix: member country is not displayed in settings

### DIFF
--- a/src/shared/components/Settings/Profile/BasicInfo/index.jsx
+++ b/src/shared/components/Settings/Profile/BasicInfo/index.jsx
@@ -95,6 +95,16 @@ export default class BasicInfo extends ConsentComponent {
         inputChanged: false,
       });
     }
+    if (nextProps.lookupData) {
+      const { countries } = nextProps.lookupData;
+      const { newBasicInfo } = this.state;
+      if (!newBasicInfo.country) {
+        const code = newBasicInfo.homeCountryCode || newBasicInfo.competitionCountryCode;
+        const { country } = countries.find(c => c.countryCode === code) || {};
+        newBasicInfo.country = country;
+        this.setState({ newBasicInfo });
+      }
+    }
   }
 
   onCheckFormValue(newBasicInfo) {
@@ -455,8 +465,6 @@ export default class BasicInfo extends ConsentComponent {
       key: country.countryCode,
       name: country.country,
     }));
-    const countryCode = newBasicInfo.homeCountryCode || newBasicInfo.competitionCountryCode;
-    const currentCountry = newBasicInfo.country || countries.find(c => c.key === countryCode);
 
     return (
       <div styleName="basic-info-container">
@@ -593,7 +601,7 @@ export default class BasicInfo extends ConsentComponent {
                 <Select
                   name="country"
                   options={countries}
-                  value={currentCountry}
+                  value={newBasicInfo.country}
                   onChange={this.onUpdateCountry}
                   placeholder="Country"
                   matchPos="start"
@@ -803,7 +811,7 @@ export default class BasicInfo extends ConsentComponent {
                   <Select
                     name="countryId"
                     options={countries}
-                    value={currentCountry}
+                    value={newBasicInfo.country}
                     onChange={this.onUpdateCountry}
                     placeholder="Country"
                     matchPos="start"

--- a/src/shared/components/Settings/Profile/BasicInfo/index.jsx
+++ b/src/shared/components/Settings/Profile/BasicInfo/index.jsx
@@ -455,6 +455,8 @@ export default class BasicInfo extends ConsentComponent {
       key: country.countryCode,
       name: country.country,
     }));
+    const countryCode = newBasicInfo.homeCountryCode || newBasicInfo.competitionCountryCode;
+    const currentCountry = newBasicInfo.country || countries.find(c => c.key === countryCode);
 
     return (
       <div styleName="basic-info-container">
@@ -591,7 +593,7 @@ export default class BasicInfo extends ConsentComponent {
                 <Select
                   name="country"
                   options={countries}
-                  value={newBasicInfo.country}
+                  value={currentCountry}
                   onChange={this.onUpdateCountry}
                   placeholder="Country"
                   matchPos="start"
@@ -801,7 +803,7 @@ export default class BasicInfo extends ConsentComponent {
                   <Select
                     name="countryId"
                     options={countries}
-                    value={newBasicInfo.country}
+                    value={currentCountry}
                     onChange={this.onUpdateCountry}
                     placeholder="Country"
                     matchPos="start"


### PR DESCRIPTION
#5501 
use homeCountryCode or competitionCountryCode as displayed country in member settings page when country is not found in the basic_info traits