### PR TITLE
fix(PM-716): used promisify instead of sync file read API

### DIFF
--- a/src/server/services/communities.js
+++ b/src/server/services/communities.js
@@ -132,7 +132,7 @@ export async function getMetadata(communityId) {
     communityId, 'metadata.json',
   );
   try {
-    metadata = JSON.parse(fs.readFileSync(uri, 'utf8'));
+    metadata = JSON.parse(await promisify(fs.readFile)(uri, 'utf8'));
   } catch (error) {
     const msg = `Failed to get metadata for ${communityId} community`;
     logger.error(msg, error);


### PR DESCRIPTION
## What's in this PR?

- Used promisify instead of sync file read API which should resolve path manipulation issue.

