### PR TITLE
fix: updated submission text for topgear challenges

### DIFF
--- a/src/shared/components/SubmissionPage/Submit/index.jsx
+++ b/src/shared/components/SubmissionPage/Submit/index.jsx
@@ -171,7 +171,8 @@ class Submit extends React.Component {
         <div>
           <ol styleName="wipro-steps">
             <li>Upload the outcome/asset/deliverable of the challenge to the repository 
-              (Wipro SharePoint folder) as specified by the project team/challenge creator.</li>
+              (Wipro SharePoint folder) as specified by the project team/challenge creator.
+            </li>
             <li>Copy the link of the outcome/asset/deliverable that was uploaded.
               Enter this link in the text box and click on “SET URL”.
             </li>
@@ -186,12 +187,12 @@ class Submit extends React.Component {
           as the submission link is proof of the work done.
         </div>
         <p styleName="wipro-paragraph">
-          Note: All deliverables/outcomes should be uploaded to the Wipro SharePoint 
-          directory <strong>ONLY</strong>. For work done directly on customer environment and involving a 
-          customer SharePoint/drive/folder link, create a word document and include a 
-          brief summary of the work done and list the deliverables/assets created along 
-          with the link to the customer SharePoint/drive/folder link and upload the word 
-          document to a Wipro SharePoint folder. And submit the link to this Word document 
+          Note: All deliverables/outcomes should be uploaded to the Wipro SharePoint
+          directory <strong>ONLY</strong>. For work done directly on customer environment and
+          involving a customer SharePoint/drive/folder link, create a word document and include a
+          brief summary of the work done and list the deliverables/assets created along
+          with the link to the customer SharePoint/drive/folder link and upload the word
+          document to a Wipro SharePoint folder. And submit the link to this Word document
           as the submission link.
         </p>
       </div>

--- a/src/shared/components/SubmissionPage/Submit/index.jsx
+++ b/src/shared/components/SubmissionPage/Submit/index.jsx
@@ -170,7 +170,7 @@ class Submit extends React.Component {
         </div>
         <div>
           <ol styleName="wipro-steps">
-            <li>Upload the outcome/asset/deliverable of the challenge to the repository 
+            <li>Upload the outcome/asset/deliverable of the challenge to the repository
               (Wipro SharePoint folder) as specified by the project team/challenge creator.
             </li>
             <li>Copy the link of the outcome/asset/deliverable that was uploaded.

--- a/src/shared/components/SubmissionPage/Submit/index.jsx
+++ b/src/shared/components/SubmissionPage/Submit/index.jsx
@@ -170,9 +170,8 @@ class Submit extends React.Component {
         </div>
         <div>
           <ol styleName="wipro-steps">
-            <li>Upload the outcome/asset/deliverable of the challenge to the repository
-              (e.g OneDrive/teams folder) as specified by the project team/challenge creator.
-            </li>
+            <li>Upload the outcome/asset/deliverable of the challenge to the repository 
+              (Wipro SharePoint folder) as specified by the project team/challenge creator.</li>
             <li>Copy the link of the outcome/asset/deliverable that was uploaded.
               Enter this link in the text box and click on “SET URL”.
             </li>
@@ -186,6 +185,15 @@ class Submit extends React.Component {
           <span styleName="wipro-red">Do not submit any irrelevant links</span>&nbsp;
           as the submission link is proof of the work done.
         </div>
+        <p styleName="wipro-paragraph">
+          Note: All deliverables/outcomes should be uploaded to the Wipro SharePoint 
+          directory <strong>ONLY</strong>. For work done directly on customer environment and involving a 
+          customer SharePoint/drive/folder link, create a word document and include a 
+          brief summary of the work done and list the deliverables/assets created along 
+          with the link to the customer SharePoint/drive/folder link and upload the word 
+          document to a Wipro SharePoint folder. And submit the link to this Word document 
+          as the submission link.
+        </p>
       </div>
     )
       : `Please follow the instructions on the Challenge Details page regarding

--- a/src/shared/components/SubmissionPage/Submit/styles.scss
+++ b/src/shared/components/SubmissionPage/Submit/styles.scss
@@ -302,6 +302,10 @@
   padding-top: 20px;
 }
 
+.wipro-paragraph {
+  padding-top: 20px;
+}
+
 .wipro-red {
   color: red;
 }


### PR DESCRIPTION
## What's in this PR?

- Updated submission text for topgear challenges

<img width="1723" alt="Screenshot 2025-03-31 at 07 14 50" src="https://github.com/user-attachments/assets/73649042-52ea-43ab-8c00-89c57ba170e7" />


