### PR TITLE
fix(PM-1192): showing wrong review scorecard link

### DIFF
--- a/src/shared/components/challenge-detail/Specification/index.jsx
+++ b/src/shared/components/challenge-detail/Specification/index.jsx
@@ -47,14 +47,22 @@ export default function ChallengeDetailsView(props) {
     metadata,
     events,
     track,
+    phases,
   } = challenge;
+
+  const getScoreCardByPhase = (phase) => {
+    const screeningPhase = phases.find(item => item.name === phase);
+    const scoreCardConstraint = screeningPhase.constraints.find(item => item.name === 'Scorecard');
+    return scoreCardConstraint ? scoreCardConstraint.value : '';
+  }
 
   const roles = (userDetails || {}).roles || [];
   const {
-    reviewScorecardId,
-    screeningScorecardId,
     forumId,
   } = legacy;
+
+  const reviewScorecardId = getScoreCardByPhase('Review');
+  const screeningScorecardId = getScoreCardByPhase('Screening');
 
   let stockArtValue = '';
   const allowStockArt = _.find(metadata, { name: 'allowStockArt' });


### PR DESCRIPTION
## What's in this PR?

- In current production version, we are showing the score card based on the legacy object
- The correct score card numbers are coming inside corresponding phases
- This PR changes the logic to use phases instead of legacy

Ticket link - https://topcoder.atlassian.net/browse/PM-1192

