### PR TITLE
PM-967 - keep env var as string

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -473,5 +473,5 @@ module.exports = {
   ACCOUNT_SETTINGS_REDIRECT_URL: 'https://account-settings.topcoder-dev.com',
   INNOVATION_CHALLENGES_TAG: 'Innovation Challenge',
   PLATFORM_SITE_URL: 'https://platform.topcoder-dev.com',
-  TOPGEAR_ALLOWED_SUBMISSIONS_DOMAINS: ['wipro365.sharepoint.com', 'wipro365-my.sharepoint.com', 'wipro365-my.sharepoint.com.mcas.ms'],
+  TOPGEAR_ALLOWED_SUBMISSIONS_DOMAINS: 'wipro365.sharepoint.com|wipro365-my.sharepoint.com|wipro365-my.sharepoint.com.mcas.ms',
 };

--- a/src/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
+++ b/src/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
@@ -136,7 +136,7 @@ class FilestackFilePicker extends React.Component {
   }
 
   isDomainAllowed(url) {
-    const domainReg = new RegExp(`^https?://(${config.TOPGEAR_ALLOWED_SUBMISSIONS_DOMAINS.join('|')})/.+`);
+    const domainReg = new RegExp(`^https?://(${config.TOPGEAR_ALLOWED_SUBMISSIONS_DOMAINS})/.+`);
     return !!url.match(domainReg);
   }
 


### PR DESCRIPTION
To avoid build issues, use string env var for the allowed domains for Topgear submissions instead of array of string. 