### PR TITLE
fix(PM-1316): dont show more filters button for copilots bucket

### DIFF
--- a/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
+++ b/src/shared/components/challenge-listing/Filters/FiltersPanel/index.jsx
@@ -68,6 +68,9 @@ export default function FiltersPanel({
   setSort,
   selectBucket,
 }) {
+  if (isCopilotOpportunitiesBucket) {
+    return null;
+  }
   if (hidden && !expanded) {
     return (
       <Button


### PR DESCRIPTION
## What's in this PR?

- dont show more filters button for copilots bucket

Ticket link - https://topcoder.atlassian.net/browse/PM-1316

