### PR TITLE
fix: sorting on copilots opportunity PM-1314

### DIFF
--- a/src/shared/services/copilotOpportunities.js
+++ b/src/shared/services/copilotOpportunities.js
@@ -10,10 +10,14 @@ const v5ApiUrl = config.API.V5;
  * @param {string} sort - Sort order (e.g., 'createdAt desc').
  * @returns {Promise<Object>} The fetched data.
  */
-export default function getCopilotOpportunities(page, pageSize = 20, sort = 'createdAt desc') {
-  const url = `${v5ApiUrl}/projects/copilots/opportunities?page=${page}&pageSize=${pageSize}&sort=${encodeURIComponent(sort)}`;
+export default function getCopilotOpportunities(page, pageSize = 20, sort = 'createdAt desc', noGrouping = true) {
+  const url = new URL(`${v5ApiUrl}/projects/copilots/opportunities`);
+  url.searchParams.append('page', page);
+  url.searchParams.append('pageSize', pageSize);
+  url.searchParams.append('sort', sort);
+  if (noGrouping) url.searchParams.append('noGrouping', 'true');
 
-  return fetch(url, {
+  return fetch(url.toString(), {
     method: 'GET',
   }).then(res => res.json());
 }

--- a/src/shared/utils/challenge-listing/sort.js
+++ b/src/shared/utils/challenge-listing/sort.js
@@ -113,7 +113,7 @@ export default {
     name: 'Status',
   },
   [SORTS.COPILOT_OPPORTUNITIES_TITLE_A_TO_Z]: {
-    func: (a, b) => a.project.name.localeCompare(b.project.name),
+    func: (a, b) => a.opportunityTitle.localeCompare(b.opportunityTitle),
     name: 'Title A-Z',
   },
   [SORTS.COPILOT_OPPORTUNITIES_TYPE]: {


### PR DESCRIPTION
Fixes the sorting on copilot opportunities page
Introduced a new param in API which will make the response ungrouped based on status.
This resolves the sorting conflicts
Also fixed a small bug with opportunity title sort