### PR TITLE
migrate: review opportunity details page to v6 review API

### DIFF
--- a/src/shared/actions/page/review-opportunity-details.js
+++ b/src/shared/actions/page/review-opportunity-details.js
@@ -3,6 +3,7 @@
  */
 import _ from 'lodash';
 import { createActions } from 'redux-actions';
+import { logger } from 'topcoder-react-lib';
 
 import { getDetails } from '../../services/reviewOpportunities';
 
@@ -26,16 +27,16 @@ function getDetailsInit() {}
  * @desc Creates an action that gets details of a review opportunity for
  *  the specified challenge.
  * @param {Number} challengeId The ID of the challenge (not the opportunity id)
+ * @param {Number} opportunityId The ID of the review opportunity
  * @param {String} tokenV3=null Optional. Topcoder auth token v3.
- * @default test
  * @return {Action}
  */
-function getDetailsDone(challengeId, opportunityId, tokenV3) {
-  return getDetails(challengeId, opportunityId, tokenV3)
+function getDetailsDone(challengeId, opportunityId) {
+  return getDetails(challengeId, opportunityId)
     .then(details => ({ details }))
     .catch((error) => {
       if (error.status !== 401) {
-        console.log('Error Getting Review Opportunity Details', error.content || error);
+        logger.error('Error Getting Review Opportunity Details', error.content || error);
       }
       return Promise.reject(error.status);
     });

--- a/src/shared/actions/page/review-opportunity-details.js
+++ b/src/shared/actions/page/review-opportunity-details.js
@@ -4,15 +4,48 @@
 import _ from 'lodash';
 import { createActions } from 'redux-actions';
 
+import { getDetails } from '../../services/reviewOpportunities';
+
+
 /* Holds valid values for the tab state. */
 export const TABS = {
   APPLICATIONS: 'APPLICATIONS',
   CHALLENGE_SPEC: 'CHALLENGE_SPEC',
 };
 
+/**
+ * @static
+ * @desc Creates an action that signals beginning of loading the review
+ *  opportunity details.
+ * @return {Action}
+ */
+function getDetailsInit() {}
+
+/**
+ * @static
+ * @desc Creates an action that gets details of a review opportunity for
+ *  the specified challenge.
+ * @param {Number} challengeId The ID of the challenge (not the opportunity id)
+ * @param {String} tokenV3=null Optional. Topcoder auth token v3.
+ * @default test
+ * @return {Action}
+ */
+function getDetailsDone(challengeId, opportunityId, tokenV3) {
+  return getDetails(challengeId, opportunityId, tokenV3)
+    .then(details => ({ details }))
+    .catch((error) => {
+      if (error.status !== 401) {
+        console.log('Error Getting Review Opportunity Details', error.content || error);
+      }
+      return Promise.reject(error.status);
+    });
+}
+
 export default createActions({
   PAGE: {
     REVIEW_OPPORTUNITY_DETAILS: {
+      GET_DETAILS_INIT: getDetailsInit,
+      GET_DETAILS_DONE: getDetailsDone,
       SELECT_TAB: _.identity,
       SET_ROLES: _.identity,
       TOGGLE_APPLY_MODAL: _.identity,

--- a/src/shared/components/ReviewOpportunityDetailsPage/FailedToLoad/index.jsx
+++ b/src/shared/components/ReviewOpportunityDetailsPage/FailedToLoad/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import './styles.scss';
 
 const FailedToLoad = () => (
-  <div styleName="comtainer">
+  <div styleName="container">
     <div styleName="failed-to-load">
       <h2>
         <span />

--- a/src/shared/components/ReviewOpportunityDetailsPage/FailedToLoad/styles.scss
+++ b/src/shared/components/ReviewOpportunityDetailsPage/FailedToLoad/styles.scss
@@ -1,6 +1,6 @@
 @import "~styles/mixins";
 
-.comtainer {
+.container {
   background: $tc-gray-neutral-dark;
   width: 100%;
   display: flex;

--- a/src/shared/components/ReviewOpportunityDetailsPage/Header/PhaseList/index.jsx
+++ b/src/shared/components/ReviewOpportunityDetailsPage/Header/PhaseList/index.jsx
@@ -22,9 +22,9 @@ const { formatDuration } = time;
  * @return {Object} The rendered React element
  */
 const renderPhase = phase => (
-  <div key={`phase-${phase.type}`} styleName={moment().isBetween(phase.scheduledStartDate, phase.scheduledEndDate) ? 'active-phase' : 'inactive-phase'}>
+  <div key={`phase-${phase.name}`} styleName={moment().isBetween(phase.scheduledStartDate, phase.scheduledEndDate) ? 'active-phase' : 'inactive-phase'}>
     <div styleName="type">
-      {phase.type}
+      {phase.name}
     </div>
     <div styleName="date">
       <strong>

--- a/src/shared/components/ReviewOpportunityDetailsPage/index.jsx
+++ b/src/shared/components/ReviewOpportunityDetailsPage/index.jsx
@@ -42,7 +42,7 @@ const ReviewOpportunityDetailsPage = ({
 
       <div styleName="header">
         <h1 styleName="challenge-title">
-          {details.challenge.title}
+          {details.challenge.name}
         </h1>
         <div styleName="tags">
           <div styleName="review-opportunity-tag">

--- a/src/shared/components/challenge-listing/ReviewOpportunityCard/index.jsx
+++ b/src/shared/components/challenge-listing/ReviewOpportunityCard/index.jsx
@@ -78,7 +78,7 @@ function ReviewOpportunityCard({
         ) /* END - DISABLED UNTIL REVIEW OPPORTUNITY RECEIVE UPDATE TO API V5 */ }
         <div styleName="challenge-details">
           <Link
-            to={`${challengesUrl}/${challenge.id}`}
+            to={`${challengesUrl}/${opportunity.challengeId}`}
           >
             {challenge.title}
           </Link>
@@ -156,7 +156,7 @@ function ReviewOpportunityCard({
           </Tooltip>
         </div>
         <Link
-          to={`/challenges/${challenge.legacyId || challenge.id}/review-opportunities`}
+          to={`/challenges/${opportunity.challengeId}/review-opportunities?opportunityId=${opportunity.id}`}
           styleName="register-button"
         >
           <span>

--- a/src/shared/containers/ReviewOpportunityDetails.jsx
+++ b/src/shared/containers/ReviewOpportunityDetails.jsx
@@ -59,10 +59,7 @@ class ReviewOpportunityDetailsContainer extends React.Component {
       fireErrorMessage(
         'Permission Required',
         <span>
-          You must have a reviewer role to apply for this review opportunity.{' '}
-          <a href="https://www.topcoder.com/community/member/reviewer-become" target="_blank" rel="noopener noreferrer">
-            Learn how to become a reviewer
-          </a>.
+          You must have a reviewer role to apply for this review opportunity.
         </span>,
       );
       return;

--- a/src/shared/reducers/page/review-opportunity-details.js
+++ b/src/shared/reducers/page/review-opportunity-details.js
@@ -4,6 +4,52 @@ import { handleActions } from 'redux-actions';
 import actions, { TABS } from 'actions/page/review-opportunity-details';
 
 /**
+ * Generates a list of unique terms ids required for the open review roles
+ * with an agreed field
+ *
+ * @param {Object} details Review Opportuny details from API
+ * @return {Array} List of unique terms
+ */
+function buildRequiredTermsList(details) {
+  const roles = details.payments.map(payment => payment.role);
+
+  const requiredTerms = _.uniqBy(
+    details.challenge.terms
+      // Sometimes roles such as Primary Reviewer have no directly equal
+      // terms entry.  Include the plain Reviewer terms when present as a back-up.
+      .filter(term => term.role === 'Reviewer' || _.includes(roles, term.role))
+      .map(term => _.pick(term, ['id', 'agreed', 'title'])),
+    term => term.id,
+  );
+
+  return requiredTerms || [];
+}
+
+
+/**
+ * Handles REVIEW_OPPORTUNITY/GET__DETAILS_DONE action.
+ * @param {Object} state
+ * @param {Object} action Payload will be JSON from api call
+ * @return {Object} New state
+ */
+function onGetDetailsDone(state, { payload, error }) {
+  if (error) {
+    return {
+      ...state,
+      authError: true,
+      isLoadingDetails: false,
+    };
+  }
+
+  return {
+    ...state,
+    details: payload.details,
+    isLoadingDetails: false,
+    requiredTerms: buildRequiredTermsList(payload.details),
+  };
+}
+
+/**
  * Creates a new reducer.
  * @param {Object} state Optional. Initial state.
  * @return {Function} Reducer.
@@ -11,6 +57,8 @@ import actions, { TABS } from 'actions/page/review-opportunity-details';
 function create(defaultState = {}) {
   const a = actions.page.reviewOpportunityDetails;
   return handleActions({
+    [a.getDetailsInit]: state => ({ ...state, isLoadingDetails: true }),
+    [a.getDetailsDone]: onGetDetailsDone,
     [a.selectTab]: (state, { payload }) => ({ ...state, selectedTab: payload }),
     [a.setRoles]: (state, { payload }) => ({ ...state, selectedRoles: payload }),
     [a.toggleApplyModal]: state => ({ ...state, applyModalOpened: !state.applyModalOpened }),

--- a/src/shared/services/reviewOpportunities.js
+++ b/src/shared/services/reviewOpportunities.js
@@ -46,7 +46,7 @@ function normalizeChallengePhases(challenge) {
 /**
    * Gets the details of the review opportunity for the corresponding challenge
    * @param {Number} challengeId The ID of the challenge (not the opportunity id)
-   * @return {Promise} Resolves to the api response in JSON.
+   * @return {Object} The combined data of the review opportunity and challenge details
    */
 export async function getDetails(challengeId, opportunityId) {
   const getReviewOpportunityUrl = new URL(`${v6ApiUrl}/review-opportunities/${opportunityId}`);


### PR DESCRIPTION
Migrates review opportunity details page to v6 review api

Adds code from topcoder-react-lib to get details of the review opportunity (getDetails)
Also fixes the frontend to work with the new API response.

For an anonymous user, we are showing the review opportunity details page. On clicking the Apply for Review button, user is redirected to login, where if they're a reviewer, the normal flow occurs. And, if they're not a reviewer, we show them an error message saying Permission denied. 

This message needs a link to a page where the user can go apply to be a reviewer - LMK of the url