### PR TITLE
PM-4662: fix MM provisional score display

### DIFF
--- a/__tests__/shared/components/challenge-detail/Header/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Header/index.jsx
@@ -81,6 +81,20 @@ function renderHeader(challengeOverrides = {}) {
 describe('Challenge detail header actions', () => {
   test('hides registration and submission actions for task challenges', () => {
     const output = renderHeader({
+      phases: [
+        {
+          isOpen: false,
+          name: 'Registration',
+          scheduledEndDate: '2030-01-02T00:00:00.000Z',
+          scheduledStartDate: '2030-01-01T00:00:00.000Z',
+        },
+        {
+          isOpen: true,
+          name: 'Submission',
+          scheduledEndDate: '2030-01-03T00:00:00.000Z',
+          scheduledStartDate: '2030-01-02T00:00:00.000Z',
+        },
+      ],
       task: {
         isTask: true,
       },

--- a/__tests__/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/__tests__/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -1,0 +1,47 @@
+import { getDisplayedScores } from '../../../../../../src/shared/components/challenge-detail/MySubmissions/SubmissionsList';
+
+describe('getDisplayedScores', () => {
+  test('uses the initial score as the provisional score before review completes', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: 100,
+        initialScore: 100,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: true,
+            name: 'Registration',
+            scheduledStartDate: '2030-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: null,
+      provisionalScore: 100,
+    });
+  });
+
+  test('shows final scores once the review phase is complete', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: 100,
+        initialScore: 95,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: false,
+            name: 'Review',
+            scheduledStartDate: '2000-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: 100,
+      provisionalScore: 95,
+    });
+  });
+});

--- a/__tests__/shared/utils/mm-review-summations.test.js
+++ b/__tests__/shared/utils/mm-review-summations.test.js
@@ -94,4 +94,35 @@ describe('buildMmSubmissionData', () => {
       }),
     ]);
   });
+
+  it('prefers initial scores over stale provisional scores from raw submissions', () => {
+    const rawSubmissions = [
+      {
+        createdAt: '2026-04-01T00:01:03.000Z',
+        finalScore: 100,
+        id: 'submission-stale-provisional',
+        initialScore: 100,
+        memberId: '1003',
+        provisionalScore: 0,
+        registrant: {
+          memberHandle: 'gamma',
+          memberId: '1003',
+          rating: 1700,
+        },
+        status: 'queued',
+      },
+    ];
+
+    const result = buildMmSubmissionData([], rawSubmissions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].submissions).toEqual([
+      expect.objectContaining({
+        finalScore: 100,
+        provisionalScore: 100,
+        status: 'queued',
+        submissionId: 'submission-stale-provisional',
+      }),
+    ]);
+  });
 });

--- a/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -74,6 +74,36 @@ const getSubmissionCreatedTime = (submission) => {
   );
 };
 
+/**
+ * Returns the scores that should be displayed for a marathon match submission row.
+ * Initial score is the authoritative provisional score for MM submissions, while
+ * final scores should remain hidden until the review phase has completed.
+ *
+ * @param {Object} submission submission attempt shown in My Submissions.
+ * @param {Object} challenge challenge that owns the submission.
+ * @returns {{ finalScore: number|null, provisionalScore: number|null }} display-ready scores.
+ */
+export function getDisplayedScores(submission = {}, challenge = {}) {
+  const toNumericScore = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const isReviewPhaseComplete = _.some(
+    challenge.phases || [],
+    phase => phase.name === 'Review' && !phase.isOpen && moment(phase.scheduledStartDate).isBefore(),
+  );
+
+  const initialScore = toNumericScore(_.get(submission, 'initialScore'));
+  const provisionalScore = toNumericScore(_.get(submission, 'provisionalScore'));
+  const finalScore = toNumericScore(_.get(submission, 'finalScore'));
+
+  return {
+    finalScore: isReviewPhaseComplete ? finalScore : null,
+    provisionalScore: !_.isNil(initialScore) ? initialScore : provisionalScore,
+  };
+}
+
 class SubmissionsListView extends React.Component {
   constructor(props) {
     super(props);
@@ -435,7 +465,7 @@ class SubmissionsListView extends React.Component {
           </div>
           {
             sortedSubmissions.map((mySubmission) => {
-              let { finalScore, provisionalScore } = mySubmission;
+              let { finalScore, provisionalScore } = getDisplayedScores(mySubmission, challenge);
               if (_.isNumber(finalScore)) {
                 if (finalScore > 0) {
                   finalScore = finalScore.toFixed(2);

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -1307,6 +1307,12 @@ function mapStateToProps(state, props) {
               return toNumericScore(match.aggregateScore);
             };
 
+            const initialScore = toNumericScore(normalizedAttempt.initialScore);
+            if (!_.isNil(initialScore)) {
+              normalizedAttempt.initialScore = initialScore;
+              normalizedAttempt.provisionalScore = initialScore;
+            }
+
             const hasProvisionalScore = !_.isNil(normalizedAttempt.provisionalScore);
             const hasFinalScore = !_.isNil(normalizedAttempt.finalScore);
 

--- a/src/shared/utils/mm-review-summations.js
+++ b/src/shared/utils/mm-review-summations.js
@@ -618,7 +618,7 @@ export function buildMmSubmissionData(reviewSummations = [], rawSubmissions = []
     const timestamp = getSubmissionTimestamp(submission);
     const timestampValue = toTimestampValue(timestamp);
     const provisionalScore = normalizeScoreValue(
-      _.get(submission, 'provisionalScore', _.get(submission, 'initialScore')),
+      _.get(submission, 'initialScore', _.get(submission, 'provisionalScore')),
     );
     const finalScore = normalizeScoreValue(_.get(submission, 'finalScore'));
     const isLatest = _.isNil(submission.isLatest)


### PR DESCRIPTION
What was broken
- Marathon Match provisional scores were showing under Final Score in My Submissions before review was complete.
- The public Submissions tab could show stale provisional scores of 0 even when the scored attempt was 100.

Root cause
- The MM normalization path preferred raw provisionalScore values over initialScore, even when provisionalScore was stale.
- My Submissions rendered finalScore directly instead of treating the review phase as the point when final scores become visible.

What was changed
- Prefer initialScore when normalizing MM provisional scores from raw submissions and normalized attempts.
- Added a display helper in My Submissions so provisional scores come from the initial score and final scores stay hidden until review completes.
- Tightened the existing header test fixture so the full Jest suite no longer confuses the registration deadline text with the Register action.

Any added/updated tests
- Added a regression test for stale MM provisional scores in mm-review-summations.
- Added My Submissions display tests covering pre-review and post-review score rendering.
- Updated the challenge-detail header action test fixture used by the full Jest suite.