### PR TITLE
PM-4648: hide task actions in challenge header

### DIFF
--- a/__tests__/shared/components/challenge-detail/Header/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Header/index.jsx
@@ -3,78 +3,6 @@ import Renderer from 'react-test-renderer/shallow';
 
 import Header from 'components/challenge-detail/Header';
 
-<<<<<<< HEAD
-const defaultProps = {
-  challenge: {
-    id: '300001',
-    drPoints: null,
-    events: [],
-    funChallenge: false,
-    metadata: [],
-    name: 'Challenge title',
-    numOfCheckpointSubmissions: 0,
-    numOfRegistrants: 0,
-    numOfSubmissions: 0,
-    phases: [
-      {
-        name: 'Registration',
-        isOpen: true,
-        scheduledEndDate: '2030-01-02T00:00:00.000Z',
-      },
-    ],
-    pointPrizes: [],
-    prizeSets: [
-      {
-        type: 'placement',
-        prizes: [{ type: 'USD', value: 1000 }],
-      },
-    ],
-    reliabilityBonus: 0,
-    skills: [],
-    status: 'ACTIVE',
-    tags: [],
-    track: 'Development',
-    type: 'Challenge',
-  },
-  challengeTypesMap: {},
-  challengesUrl: '/challenges',
-  checkpoints: {},
-  hasFirstPlacement: false,
-  hasRecommendedChallenges: false,
-  hasRegistered: false,
-  hasThriveArticles: false,
-  isLoggedIn: true,
-  mySubmissions: [],
-  numWinners: 0,
-  onSelectorClicked: () => {},
-  onSort: () => {},
-  onToggleDeadlines: () => {},
-  openForRegistrationChallenges: {},
-  registerForChallenge: () => {},
-  registering: false,
-  selectedView: 'details',
-  setChallengeListingFilter: () => {},
-  showDeadlineDetail: false,
-  submissionEnded: false,
-  unregisterFromChallenge: () => {},
-  unregistering: false,
-  viewAsTable: false,
-};
-
-/**
- * Collects text nodes from a shallow-rendered React tree.
- * @param {*} node React node to inspect.
- * @returns {string[]} Flattened text content.
- */
-function collectText(node) {
-  if (typeof node === 'string') return [node];
-  if (!node || !node.props) return [];
-
-  return React.Children.toArray(node.props.children).reduce(
-    (result, child) => result.concat(collectText(child)),
-    [],
-  );
-=======
 function collectText(node) {
   if (typeof node === 'string') {
     return [node];
@@ -148,40 +76,33 @@ function renderHeader(challengeOverrides = {}) {
   );
 
   return renderer.getRenderOutput();
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 }
 
 describe('Challenge detail header actions', () => {
   test('hides registration and submission actions for task challenges', () => {
-<<<<<<< HEAD
-    const renderer = new Renderer();
-
-    renderer.render((
-      <Header
-        {...defaultProps}
-        challenge={{
-          ...defaultProps.challenge,
-          type: 'Task',
-        }}
-      />
-    ));
-
-    const output = renderer.getRenderOutput();
-=======
     const output = renderHeader({
       task: {
         isTask: true,
       },
       type: 'Task',
     });
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 
     expect(collectText(output)).not.toContain('Register');
     expect(collectText(output)).not.toContain('Unregister');
     expect(collectText(output)).not.toContain('Submit a solution');
   });
-<<<<<<< HEAD
-=======
+
+  test('hides registration and submission actions for task payloads from work app', () => {
+    const output = renderHeader({
+      task: {
+        isTask: true,
+      },
+    });
+
+    expect(collectText(output)).not.toContain('Register');
+    expect(collectText(output)).not.toContain('Unregister');
+    expect(collectText(output)).not.toContain('Submit a solution');
+  });
 
   test('shows registration and submission actions for non-task challenges', () => {
     const output = renderHeader();
@@ -189,5 +110,4 @@ describe('Challenge detail header actions', () => {
     expect(collectText(output)).toContain('Register');
     expect(collectText(output)).toContain('Submit a solution');
   });
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 });

--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -148,13 +148,9 @@ export default function ChallengeHeader(props) {
 
   const trackName = getTrackName(track);
   const typeName = getTypeName(type);
-<<<<<<< HEAD
-  const isTaskChallenge = typeName === 'Task';
-=======
   const isTaskChallenge = typeName === 'Task'
     || _.get(challenge, 'task.isTask') === true
     || _.get(challenge, 'legacy.pureV5Task') === true;
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
   const trackLower = trackName ? trackName.replace(' ', '-').toLowerCase() : 'design';
 
   const eventNames = (events || []).map((event => (event.eventName || '').toUpperCase()));
@@ -513,72 +509,7 @@ export default function ChallengeHeader(props) {
                 }
             </div>
             <div styleName="challenge-ops-wrapper">
-<<<<<<< HEAD
               {challengeActions}
-=======
-              {!isTopCrowdChallenge ? (
-                !isTaskChallenge && (
-                  <div styleName="challenge-ops-container">
-                    {hasRegistered ? (
-                      <PrimaryButton
-                        disabled={unregisterButtonDisabled}
-                        theme={{
-                          button: unregisterButtonDisabled
-                            ? style.submitButtonDisabled
-                            : style.submitButton,
-                        }}
-                        forceA
-                        onClick={unregisterFromChallenge}
-                      >
-                        Unregister
-                      </PrimaryButton>
-                    ) : (
-                      <PrimaryButton
-                        disabled={registerButtonDisabled}
-                        theme={{
-                          button: registerButtonDisabled
-                            ? style.submitButtonDisabled
-                            : style.submitButton,
-                        }}
-                        forceA
-                        onClick={registerForChallenge}
-                      >
-                        Register
-                      </PrimaryButton>
-                    )}
-                    <PrimaryButton
-                      disabled={disabled}
-                      theme={{ button: disabled ? style.submitButtonDisabled : style.submitButton }}
-                      to={`${challengesUrl}/${challengeId}/submit`}
-                      forceA
-                    >
-                      <IconsUpload />
-                      <span>Submit a solution</span>
-                    </PrimaryButton>
-                    {
-                      trackName === COMPETITION_TRACKS.DES && hasRegistered && !unregistering
-                        && hasSubmissions && (
-                        <PrimaryButton
-                          theme={{ button: style.submitButton }}
-                          to={`${challengesUrl}/${challengeId}/my-submissions`}
-                        >
-                          View Submissions
-                        </PrimaryButton>
-                      )
-                    }
-                  </div>
-                )
-              ) : (
-                <Link
-                  openNewTab
-                  to={`${topcrowdLink}`}
-                  styleName="topcrowd-container"
-                >
-                  <span>View details on Topcoder platform</span>
-                  <IconsOpenInNew />
-                </Link>
-              )}
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
             </div>
           </div>
           <div styleName="deadlines-view">


### PR DESCRIPTION
What was broken
Task challenge detail pages could still render Register, Unregister, and Submit a solution actions for users who should not see them.

Root cause (if identifiable)
The challenge detail header only treated challenges with a Task type name as tasks, while tasks created from the newer work app are identified through task metadata on the payload instead.

What was changed
Updated the challenge detail header to reuse task detection that also respects task metadata on the challenge payload, so task pages no longer render the register, unregister, or submit actions.
Resolved the conflicted header/test blocks so the header keeps the current action rendering path and the task guard applies consistently.

Any added/updated tests
Updated the challenge detail header tests to cover both classic task challenges and work-app task payloads, and to confirm non-task challenges still show the actions.
