### PR TITLE
PM-4648: hide task challenge action buttons

### DIFF
--- a/__tests__/shared/components/challenge-detail/Header/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Header/index.jsx
@@ -3,78 +3,6 @@ import Renderer from 'react-test-renderer/shallow';
 
 import Header from 'components/challenge-detail/Header';
 
-<<<<<<< HEAD
-const defaultProps = {
-  challenge: {
-    id: '300001',
-    drPoints: null,
-    events: [],
-    funChallenge: false,
-    metadata: [],
-    name: 'Challenge title',
-    numOfCheckpointSubmissions: 0,
-    numOfRegistrants: 0,
-    numOfSubmissions: 0,
-    phases: [
-      {
-        name: 'Registration',
-        isOpen: true,
-        scheduledEndDate: '2030-01-02T00:00:00.000Z',
-      },
-    ],
-    pointPrizes: [],
-    prizeSets: [
-      {
-        type: 'placement',
-        prizes: [{ type: 'USD', value: 1000 }],
-      },
-    ],
-    reliabilityBonus: 0,
-    skills: [],
-    status: 'ACTIVE',
-    tags: [],
-    track: 'Development',
-    type: 'Challenge',
-  },
-  challengeTypesMap: {},
-  challengesUrl: '/challenges',
-  checkpoints: {},
-  hasFirstPlacement: false,
-  hasRecommendedChallenges: false,
-  hasRegistered: false,
-  hasThriveArticles: false,
-  isLoggedIn: true,
-  mySubmissions: [],
-  numWinners: 0,
-  onSelectorClicked: () => {},
-  onSort: () => {},
-  onToggleDeadlines: () => {},
-  openForRegistrationChallenges: {},
-  registerForChallenge: () => {},
-  registering: false,
-  selectedView: 'details',
-  setChallengeListingFilter: () => {},
-  showDeadlineDetail: false,
-  submissionEnded: false,
-  unregisterFromChallenge: () => {},
-  unregistering: false,
-  viewAsTable: false,
-};
-
-/**
- * Collects text nodes from a shallow-rendered React tree.
- * @param {*} node React node to inspect.
- * @returns {string[]} Flattened text content.
- */
-function collectText(node) {
-  if (typeof node === 'string') return [node];
-  if (!node || !node.props) return [];
-
-  return React.Children.toArray(node.props.children).reduce(
-    (result, child) => result.concat(collectText(child)),
-    [],
-  );
-=======
 function collectText(node) {
   if (typeof node === 'string') {
     return [node];
@@ -93,7 +21,9 @@ function renderHeader(challengeOverrides = {}) {
   renderer.render(
     <Header
       challenge={{
+        drPoints: null,
         events: [],
+        funChallenge: false,
         id: 'challenge-id',
         legacy: {},
         metadata: [],
@@ -110,7 +40,13 @@ function renderHeader(challengeOverrides = {}) {
           },
         ],
         pointPrizes: [],
-        prizeSets: [],
+        prizeSets: [
+          {
+            type: 'placement',
+            prizes: [{ type: 'USD', value: 1000 }],
+          },
+        ],
+        reliabilityBonus: 0,
         skills: [],
         status: 'ACTIVE',
         tags: [],
@@ -118,12 +54,9 @@ function renderHeader(challengeOverrides = {}) {
         type: 'Challenge',
         ...challengeOverrides,
       }}
-      challengeTypesMap={[
-        { abbreviation: 'CH', name: 'Challenge' },
-        { abbreviation: 'TSK', name: 'Task' },
-      ]}
+      challengeTypesMap={{}}
       challengesUrl="/challenges"
-      checkpoints={[]}
+      checkpoints={{}}
       hasFirstPlacement={false}
       hasRecommendedChallenges={false}
       hasRegistered={false}
@@ -148,40 +81,42 @@ function renderHeader(challengeOverrides = {}) {
   );
 
   return renderer.getRenderOutput();
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 }
 
 describe('Challenge detail header actions', () => {
-  test('hides registration and submission actions for task challenges', () => {
-<<<<<<< HEAD
-    const renderer = new Renderer();
-
-    renderer.render((
-      <Header
-        {...defaultProps}
-        challenge={{
-          ...defaultProps.challenge,
-          type: 'Task',
-        }}
-      />
-    ));
-
-    const output = renderer.getRenderOutput();
-=======
+  test('hides registration and submission actions for classic task challenges', () => {
     const output = renderHeader({
-      task: {
-        isTask: true,
-      },
       type: 'Task',
     });
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 
     expect(collectText(output)).not.toContain('Register');
     expect(collectText(output)).not.toContain('Unregister');
     expect(collectText(output)).not.toContain('Submit a solution');
   });
-<<<<<<< HEAD
-=======
+
+  test('hides registration and submission actions for work-app task payloads', () => {
+    const output = renderHeader({
+      task: {
+        isTask: true,
+      },
+    });
+
+    expect(collectText(output)).not.toContain('Register');
+    expect(collectText(output)).not.toContain('Unregister');
+    expect(collectText(output)).not.toContain('Submit a solution');
+  });
+
+  test('hides registration and submission actions for pure v5 task payloads', () => {
+    const output = renderHeader({
+      legacy: {
+        pureV5Task: true,
+      },
+    });
+
+    expect(collectText(output)).not.toContain('Register');
+    expect(collectText(output)).not.toContain('Unregister');
+    expect(collectText(output)).not.toContain('Submit a solution');
+  });
 
   test('shows registration and submission actions for non-task challenges', () => {
     const output = renderHeader();
@@ -189,5 +124,4 @@ describe('Challenge detail header actions', () => {
     expect(collectText(output)).toContain('Register');
     expect(collectText(output)).toContain('Submit a solution');
   });
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 });

--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -148,13 +148,9 @@ export default function ChallengeHeader(props) {
 
   const trackName = getTrackName(track);
   const typeName = getTypeName(type);
-<<<<<<< HEAD
-  const isTaskChallenge = typeName === 'Task';
-=======
   const isTaskChallenge = typeName === 'Task'
     || _.get(challenge, 'task.isTask') === true
     || _.get(challenge, 'legacy.pureV5Task') === true;
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
   const trackLower = trackName ? trackName.replace(' ', '-').toLowerCase() : 'design';
 
   const eventNames = (events || []).map((event => (event.eventName || '').toUpperCase()));
@@ -513,72 +509,7 @@ export default function ChallengeHeader(props) {
                 }
             </div>
             <div styleName="challenge-ops-wrapper">
-<<<<<<< HEAD
               {challengeActions}
-=======
-              {!isTopCrowdChallenge ? (
-                !isTaskChallenge && (
-                  <div styleName="challenge-ops-container">
-                    {hasRegistered ? (
-                      <PrimaryButton
-                        disabled={unregisterButtonDisabled}
-                        theme={{
-                          button: unregisterButtonDisabled
-                            ? style.submitButtonDisabled
-                            : style.submitButton,
-                        }}
-                        forceA
-                        onClick={unregisterFromChallenge}
-                      >
-                        Unregister
-                      </PrimaryButton>
-                    ) : (
-                      <PrimaryButton
-                        disabled={registerButtonDisabled}
-                        theme={{
-                          button: registerButtonDisabled
-                            ? style.submitButtonDisabled
-                            : style.submitButton,
-                        }}
-                        forceA
-                        onClick={registerForChallenge}
-                      >
-                        Register
-                      </PrimaryButton>
-                    )}
-                    <PrimaryButton
-                      disabled={disabled}
-                      theme={{ button: disabled ? style.submitButtonDisabled : style.submitButton }}
-                      to={`${challengesUrl}/${challengeId}/submit`}
-                      forceA
-                    >
-                      <IconsUpload />
-                      <span>Submit a solution</span>
-                    </PrimaryButton>
-                    {
-                      trackName === COMPETITION_TRACKS.DES && hasRegistered && !unregistering
-                        && hasSubmissions && (
-                        <PrimaryButton
-                          theme={{ button: style.submitButton }}
-                          to={`${challengesUrl}/${challengeId}/my-submissions`}
-                        >
-                          View Submissions
-                        </PrimaryButton>
-                      )
-                    }
-                  </div>
-                )
-              ) : (
-                <Link
-                  openNewTab
-                  to={`${topcrowdLink}`}
-                  styleName="topcrowd-container"
-                >
-                  <span>View details on Topcoder platform</span>
-                  <IconsOpenInNew />
-                </Link>
-              )}
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
             </div>
           </div>
           <div styleName="deadlines-view">


### PR DESCRIPTION
What was broken

Task challenges created from the new work app still rendered Register, Unregister, and Submit a solution controls on the challenge detail header.

Root cause

The header only treated challenges with a literal type name of Task as task challenges, so newer payloads flagged through task.isTask or legacy.pureV5Task fell through as normal challenges.

What was changed

Extended the task detection in the challenge detail header to honor work-app and pure V5 task flags while preserving the existing header rendering flow.
Resolved the committed merge-marker conflict in the header and kept the current phase timing logic intact.

Any added/updated tests

Updated the challenge detail header tests to cover classic task challenges, work-app task payloads, pure V5 task payloads, and the non-task control case.
