### PR TITLE
PM-4608: show MM final scores during active review

### DIFF
--- a/__tests__/shared/utils/challenge-detail/mm-final-results.test.js
+++ b/__tests__/shared/utils/challenge-detail/mm-final-results.test.js
@@ -1,0 +1,59 @@
+/* eslint-env jest */
+import {
+  hasVisibleMmFinalResults,
+  isReviewPhaseComplete,
+  shouldShowFinalMmResults,
+} from '../../../../src/shared/utils/challenge-detail/mm-final-results';
+
+describe('mm-final-results utilities', () => {
+  const activeReviewChallenge = {
+    phases: [
+      {
+        isOpen: true,
+        name: 'Review',
+        scheduledStartDate: '2030-01-01T00:00:00.000Z',
+      },
+    ],
+  };
+
+  it('detects when the review phase has completed', () => {
+    expect(isReviewPhaseComplete({
+      phases: [
+        {
+          isOpen: false,
+          name: 'Review',
+          scheduledStartDate: '2000-01-01T00:00:00.000Z',
+        },
+      ],
+    })).toBe(true);
+  });
+
+  it('keeps final Marathon Match results hidden while review is active and no final score exists', () => {
+    expect(shouldShowFinalMmResults(activeReviewChallenge, [
+      {
+        finalRank: null,
+        submissions: [
+          {
+            finalScore: null,
+          },
+        ],
+      },
+    ])).toBe(false);
+  });
+
+  it('shows final Marathon Match results as soon as a final score is available', () => {
+    const mmSubmissions = [
+      {
+        finalRank: 1,
+        submissions: [
+          {
+            finalScore: 100,
+          },
+        ],
+      },
+    ];
+
+    expect(hasVisibleMmFinalResults(mmSubmissions)).toBe(true);
+    expect(shouldShowFinalMmResults(activeReviewChallenge, mmSubmissions)).toBe(true);
+  });
+});

--- a/__tests__/shared/utils/challenge-detail/my-submission-scores.test.js
+++ b/__tests__/shared/utils/challenge-detail/my-submission-scores.test.js
@@ -1,0 +1,70 @@
+/* eslint-env jest */
+import { getDisplayedScores } from '../../../../src/shared/components/challenge-detail/MySubmissions/SubmissionsList';
+
+describe('getDisplayedScores', () => {
+  it('shows final scores when a system review has already produced one', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: 100,
+        initialScore: 100,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: true,
+            name: 'Registration',
+            scheduledStartDate: '2030-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: 100,
+      provisionalScore: 100,
+    });
+  });
+
+  it('hides final scores while review is active and no final result exists yet', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: null,
+        initialScore: 95,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: true,
+            name: 'Registration',
+            scheduledStartDate: '2030-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: null,
+      provisionalScore: 95,
+    });
+  });
+
+  it('shows final scores once the review phase is complete', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: 100,
+        initialScore: 95,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: false,
+            name: 'Review',
+            scheduledStartDate: '2000-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: 100,
+      provisionalScore: 95,
+    });
+  });
+});

--- a/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { PrimaryButton, Modal } from 'topcoder-react-ui-kit';
 import PT from 'prop-types';
 import { services } from 'topcoder-react-lib';
+import { isReviewPhaseComplete } from 'utils/challenge-detail/mm-final-results';
 import sortList from 'utils/challenge-detail/sort';
 import { getSubmissionStatus } from 'utils/challenge-detail/submission-status';
 
@@ -73,6 +74,34 @@ const getSubmissionCreatedTime = (submission) => {
     || submission.updatedAt
   );
 };
+
+/**
+ * Returns the scores that should be displayed for a Marathon Match submission.
+ *
+ * @param {Object} submission submission attempt shown in My Submissions.
+ * @param {Object} challenge challenge that owns the submission.
+ * @returns {{ finalScore: number|null, provisionalScore: number|null }} display-ready scores.
+ */
+export function getDisplayedScores(submission = {}, challenge = {}) {
+  const toNumericScore = (value) => {
+    if (_.isNil(value) || value === '' || value === '-') {
+      return null;
+    }
+
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const initialScore = toNumericScore(_.get(submission, 'initialScore'));
+  const provisionalScore = toNumericScore(_.get(submission, 'provisionalScore'));
+  const finalScore = toNumericScore(_.get(submission, 'finalScore'));
+  const showFinalScore = isReviewPhaseComplete(challenge) || !_.isNil(finalScore);
+
+  return {
+    finalScore: showFinalScore ? finalScore : null,
+    provisionalScore: !_.isNil(initialScore) ? initialScore : provisionalScore,
+  };
+}
 
 class SubmissionsListView extends React.Component {
   constructor(props) {
@@ -435,7 +464,7 @@ class SubmissionsListView extends React.Component {
           </div>
           {
             sortedSubmissions.map((mySubmission) => {
-              let { finalScore, provisionalScore } = mySubmission;
+              let { finalScore, provisionalScore } = getDisplayedScores(mySubmission, challenge);
               if (_.isNumber(finalScore)) {
                 if (finalScore > 0) {
                   finalScore = finalScore.toFixed(2);

--- a/src/shared/components/challenge-detail/Submissions/SubmissionInformationModal/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionInformationModal/index.jsx
@@ -61,7 +61,7 @@ class SubmissionInformationModal extends React.Component {
   render() {
     const {
       toggleTestcase, onClose, isLoadingSubmissionInformation,
-      submissionInformation, isReviewPhaseComplete,
+      submissionInformation, showFinalResults,
     } = this.props;
     const submissionBasicInfo = isLoadingSubmissionInformation
       ? null : this.getSubmissionBasicInfo();
@@ -90,7 +90,7 @@ class SubmissionInformationModal extends React.Component {
                         <div
                           styleName="modal.details-item"
                         >
-                          {(!submissionBasicInfo.finalScore && submissionBasicInfo.finalScore !== 0) || !isReviewPhaseComplete ? '-' : submissionBasicInfo.finalScore}
+                          {(!submissionBasicInfo.finalScore && submissionBasicInfo.finalScore !== 0) || !showFinalResults ? '-' : submissionBasicInfo.finalScore}
                         </div>
                         <div
                           styleName="modal.details-item"
@@ -180,7 +180,7 @@ SubmissionInformationModal.propTypes = {
   openTestcase: PT.shape({}).isRequired,
   clearTestcaseOpen: PT.func.isRequired,
   submission: PT.shape().isRequired,
-  isReviewPhaseComplete: PT.bool.isRequired,
+  showFinalResults: PT.bool.isRequired,
 };
 
 export default SubmissionInformationModal;

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/SubmissionHistoryRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/SubmissionHistoryRow/index.jsx
@@ -27,7 +27,7 @@ export default function SubmissionHistoryRow({
   provisionalScore,
   submissionTime,
   createdAt,
-  isReviewPhaseComplete,
+  showFinalResults,
   status,
   challengeStatus,
   auth,
@@ -63,7 +63,7 @@ export default function SubmissionHistoryRow({
     }
   };
   const getFinalScore = () => {
-    if (!isReviewPhaseComplete) {
+    if (!showFinalResults) {
       return 'N/A';
     }
     if (finalScoreValue === null) {
@@ -139,7 +139,7 @@ export default function SubmissionHistoryRow({
 SubmissionHistoryRow.defaultProps = {
   finalScore: null,
   provisionalScore: null,
-  isReviewPhaseComplete: false,
+  showFinalResults: false,
   isLoggedIn: false,
   createdAt: null,
   submissionTime: null,
@@ -169,7 +169,7 @@ SubmissionHistoryRow.propTypes = {
     PT.oneOf([null]),
   ]),
   challengeStatus: PT.string.isRequired,
-  isReviewPhaseComplete: PT.bool,
+  showFinalResults: PT.bool,
   auth: PT.shape().isRequired,
   numWinners: PT.number.isRequired,
   submissionId: PT.string.isRequired,

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
@@ -20,7 +20,7 @@ import style from './style.scss';
 
 export default function SubmissionRow({
   isMM, isRDM, openHistory, member, submissions, toggleHistory, challengeStatus,
-  isReviewPhaseComplete, finalRank, provisionalRank, onShowPopup, rating, viewAsTable,
+  showFinalResults, finalRank, provisionalRank, onShowPopup, rating, viewAsTable,
   numWinners, auth, isLoggedIn, isF2F, isBugHunt,
 }) {
   const submissionList = Array.isArray(submissions) ? submissions : [];
@@ -66,7 +66,7 @@ export default function SubmissionRow({
   };
 
   const getFinalReviewResult = () => {
-    if (!isReviewPhaseComplete) {
+    if (!showFinalResults) {
       return 'N/A';
     }
     if (_.isNil(finalScore)) {
@@ -103,7 +103,7 @@ export default function SubmissionRow({
     ? submissionMoment.format('MMM DD, YYYY HH:mm')
     : 'N/A';
 
-  const finalRankDisplay = (isReviewPhaseComplete && _.isFinite(finalRank)) ? finalRank : 'N/A';
+  const finalRankDisplay = (showFinalResults && _.isFinite(finalRank)) ? finalRank : 'N/A';
   const provisionalRankDisplay = _.isFinite(provisionalRank) ? provisionalRank : 'N/A';
   const ratingDisplay = _.isFinite(rating) ? rating : '-';
   const ratingLevelStyle = `col level-${getRatingLevel(rating)}`;
@@ -306,7 +306,7 @@ export default function SubmissionRow({
               {
                 submissionList.map((submissionHistory, index) => (
                   <SubmissionHistoryRow
-                    isReviewPhaseComplete={isReviewPhaseComplete}
+                    showFinalResults={showFinalResults}
                     isMM={isMM}
                     isRDM={isRDM}
                     challengeStatus={challengeStatus}
@@ -339,7 +339,7 @@ export default function SubmissionRow({
 
 SubmissionRow.defaultProps = {
   toggleHistory: () => {},
-  isReviewPhaseComplete: false,
+  showFinalResults: false,
   finalRank: null,
   provisionalRank: null,
   rating: null,
@@ -390,7 +390,7 @@ SubmissionRow.propTypes = {
   })).isRequired,
   rating: PT.number,
   toggleHistory: PT.func,
-  isReviewPhaseComplete: PT.bool,
+  showFinalResults: PT.bool,
   finalRank: PT.number,
   provisionalRank: PT.number,
   onShowPopup: PT.func.isRequired,

--- a/src/shared/components/challenge-detail/Submissions/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/index.jsx
@@ -21,6 +21,7 @@ import cn from 'classnames';
 import { Button } from 'topcoder-react-ui-kit';
 import DateSortIcon from 'assets/images/icon-date-sort.svg';
 import SortIcon from 'assets/images/icon-sort.svg';
+import { shouldShowFinalMmResults as resolveShouldShowFinalMmResults } from 'utils/challenge-detail/mm-final-results';
 import { getSubmissionId } from 'utils/submissions';
 import { compressFiles } from 'utils/files';
 
@@ -109,7 +110,7 @@ class SubmissionsComponent extends React.Component {
     this.getFlagFirstTry = this.getFlagFirstTry.bind(this);
     this.updateSortedSubmissions = this.updateSortedSubmissions.bind(this);
     this.sortSubmissions = this.sortSubmissions.bind(this);
-    this.checkIsReviewPhaseComplete = this.checkIsReviewPhaseComplete.bind(this);
+    this.shouldShowFinalMmResults = this.shouldShowFinalMmResults.bind(this);
   }
 
   componentDidMount() {
@@ -208,7 +209,7 @@ class SubmissionsComponent extends React.Component {
   /**
      * Get submission sort parameter
      */
-  getSubmissionsSortParam(isMM, isReviewPhaseComplete) {
+  getSubmissionsSortParam(isMM, showFinalMmResults) {
     const {
       submissionsSort,
     } = this.props;
@@ -216,7 +217,7 @@ class SubmissionsComponent extends React.Component {
     if (!field) {
       field = 'Submission Date'; // default field for submission sorting
       if (isMM) {
-        if (isReviewPhaseComplete) {
+        if (showFinalMmResults) {
           field = 'Final Rank';
         } else {
           field = 'Provisional Rank';
@@ -263,8 +264,8 @@ class SubmissionsComponent extends React.Component {
       return;
     }
     const isMM = this.isMM();
-    const isReviewPhaseComplete = this.checkIsReviewPhaseComplete();
-    const { field, sort } = this.getSubmissionsSortParam(isMM, isReviewPhaseComplete);
+    const showFinalMmResults = this.shouldShowFinalMmResults();
+    const { field, sort } = this.getSubmissionsSortParam(isMM, showFinalMmResults);
 
     // For non-MM submissions that are grouped by member, we need to adjust the sorting logic
     const isGrouped = !isMM && submissions.length > 0 && submissions[0].submissions;
@@ -366,7 +367,7 @@ class SubmissionsComponent extends React.Component {
           break;
         }
         case 'Final Rank': {
-          if (isReviewPhaseComplete) {
+          if (showFinalMmResults) {
             valueA = toRankValue(_.get(a, 'finalRank'));
             valueB = toRankValue(_.get(b, 'finalRank'));
           }
@@ -409,22 +410,15 @@ class SubmissionsComponent extends React.Component {
   }
 
   /**
-     * Check if review phase complete
-     */
-  checkIsReviewPhaseComplete() {
+   * Returns whether Marathon Match final results should be shown.
+   */
+  shouldShowFinalMmResults() {
     const {
       challenge,
+      mmSubmissions,
     } = this.props;
 
-    const allPhases = challenge.phases || [];
-
-    let isReviewPhaseComplete = false;
-    _.forEach(allPhases, (phase) => {
-      if (phase.name === 'Review' && !phase.isOpen && moment(phase.scheduledStartDate).isBefore()) {
-        isReviewPhaseComplete = true;
-      }
-    });
-    return isReviewPhaseComplete;
+    return resolveShouldShowFinalMmResults(challenge, mmSubmissions);
   }
 
   render() {
@@ -465,9 +459,9 @@ class SubmissionsComponent extends React.Component {
     const isMM = this.isMM();
     const isRDM = checkIsRDM(challenge);
     const isLoggedIn = !_.isEmpty(auth.tokenV3);
-    const isReviewPhaseComplete = this.checkIsReviewPhaseComplete();
+    const showFinalMmResults = this.shouldShowFinalMmResults();
 
-    const { field, sort } = this.getSubmissionsSortParam(isMM, isReviewPhaseComplete);
+    const { field, sort } = this.getSubmissionsSortParam(isMM, showFinalMmResults);
     const revertSort = (sort === 'desc') ? 'asc' : 'desc';
 
     const {
@@ -1007,7 +1001,7 @@ class SubmissionsComponent extends React.Component {
               sortedSubmissions.map((submission, index) => (
                 <SubmissionRow
                   submissions={sortedSubmissions}
-                  isReviewPhaseComplete={isReviewPhaseComplete}
+                  showFinalResults={showFinalMmResults}
                   isMM={isMM}
                   isRDM={isRDM}
                   key={submission.member}
@@ -1034,7 +1028,7 @@ class SubmissionsComponent extends React.Component {
               sortedSubmissions.map((memberGroup, index) => (
                 <SubmissionRow
                   submissions={memberGroup.submissions}
-                  isReviewPhaseComplete={isReviewPhaseComplete}
+                  showFinalResults={showFinalMmResults}
                   isMM={isMM}
                   isRDM={isRDM}
                   key={memberGroup.member}
@@ -1084,7 +1078,7 @@ class SubmissionsComponent extends React.Component {
                 openTestcase={submissionTestcaseOpen}
                 clearTestcaseOpen={clearSubmissionTestcaseOpen}
                 submission={modalSubmissionBasicInfo()}
-                isReviewPhaseComplete={isReviewPhaseComplete}
+                showFinalResults={showFinalMmResults}
               />
             )
           }

--- a/src/shared/utils/challenge-detail/mm-final-results.js
+++ b/src/shared/utils/challenge-detail/mm-final-results.js
@@ -1,0 +1,64 @@
+import _ from 'lodash';
+import moment from 'moment';
+
+/**
+ * Normalizes a displayed score or rank value into a finite number.
+ *
+ * @param {number|string|null|undefined} value score or rank candidate.
+ * @returns {number|null} normalized numeric value, or null when unavailable.
+ */
+function toFiniteScore(value) {
+  if (_.isNil(value) || value === '' || value === '-') {
+    return null;
+  }
+
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+/**
+ * Returns whether the challenge review phase has already closed.
+ *
+ * @param {Object} challenge challenge detail payload.
+ * @returns {boolean} true when the review phase is no longer open.
+ */
+export function isReviewPhaseComplete(challenge = {}) {
+  return _.some(
+    challenge.phases || [],
+    phase => phase.name === 'Review' && !phase.isOpen && moment(phase.scheduledStartDate).isBefore(),
+  );
+}
+
+/**
+ * Returns whether Marathon Match final scores or ranks already exist in the
+ * loaded submission payload, even if the review phase is still active.
+ *
+ * @param {Array} mmSubmissions grouped Marathon Match submissions.
+ * @returns {boolean} true when at least one final result is available.
+ */
+export function hasVisibleMmFinalResults(mmSubmissions = []) {
+  return _.some(mmSubmissions, (entry) => {
+    const finalRank = toFiniteScore(_.get(entry, 'finalRank'));
+    if (!_.isNil(finalRank)) {
+      return true;
+    }
+
+    return _.some(_.get(entry, 'submissions', []), (submission) => {
+      const finalScore = toFiniteScore(_.get(submission, 'finalScore'));
+      return !_.isNil(finalScore);
+    });
+  });
+}
+
+/**
+ * Returns whether Marathon Match final results should be shown on the
+ * challenge detail page.
+ *
+ * @param {Object} challenge challenge detail payload.
+ * @param {Array} mmSubmissions grouped Marathon Match submissions.
+ * @returns {boolean} true when final results are ready for display.
+ */
+export function shouldShowFinalMmResults(challenge = {}, mmSubmissions = []) {
+  return isReviewPhaseComplete(challenge)
+    || hasVisibleMmFinalResults(mmSubmissions);
+}


### PR DESCRIPTION
What was broken
Marathon Match challenges that run system tests during the Review phase continued to hide final ranks and scores until the Review phase closed. Users only saw provisional data even after final result payloads were already available.

Root cause
The Community App only switched to final-result display after the Review phase finished. It did not check whether Marathon Match final scores or ranks were already present in the loaded submissions while Review was still open.

What was changed
Added a Marathon Match final-results utility that detects visible final scores or ranks and reuses the existing review-phase completion check.
Updated the submissions tables, history modal, and My Submissions score rendering to show final data as soon as final Marathon Match results exist, while preserving provisional display when they do not.
Adjusted Marathon Match default sorting so final rank becomes the primary sort once final results are available.

Any added/updated tests
Added utility coverage for Marathon Match final-result visibility decisions.
Added My Submissions score-display coverage for active-review final scores and initial-score fallback behavior.
Retained focused Marathon Match review summation regression coverage in validation.
