### PR TITLE
PM-4662: fix MM provisional score display

### DIFF
--- a/__tests__/shared/components/challenge-detail/Header/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Header/index.jsx
@@ -3,78 +3,6 @@ import Renderer from 'react-test-renderer/shallow';
 
 import Header from 'components/challenge-detail/Header';
 
-<<<<<<< HEAD
-const defaultProps = {
-  challenge: {
-    id: '300001',
-    drPoints: null,
-    events: [],
-    funChallenge: false,
-    metadata: [],
-    name: 'Challenge title',
-    numOfCheckpointSubmissions: 0,
-    numOfRegistrants: 0,
-    numOfSubmissions: 0,
-    phases: [
-      {
-        name: 'Registration',
-        isOpen: true,
-        scheduledEndDate: '2030-01-02T00:00:00.000Z',
-      },
-    ],
-    pointPrizes: [],
-    prizeSets: [
-      {
-        type: 'placement',
-        prizes: [{ type: 'USD', value: 1000 }],
-      },
-    ],
-    reliabilityBonus: 0,
-    skills: [],
-    status: 'ACTIVE',
-    tags: [],
-    track: 'Development',
-    type: 'Challenge',
-  },
-  challengeTypesMap: {},
-  challengesUrl: '/challenges',
-  checkpoints: {},
-  hasFirstPlacement: false,
-  hasRecommendedChallenges: false,
-  hasRegistered: false,
-  hasThriveArticles: false,
-  isLoggedIn: true,
-  mySubmissions: [],
-  numWinners: 0,
-  onSelectorClicked: () => {},
-  onSort: () => {},
-  onToggleDeadlines: () => {},
-  openForRegistrationChallenges: {},
-  registerForChallenge: () => {},
-  registering: false,
-  selectedView: 'details',
-  setChallengeListingFilter: () => {},
-  showDeadlineDetail: false,
-  submissionEnded: false,
-  unregisterFromChallenge: () => {},
-  unregistering: false,
-  viewAsTable: false,
-};
-
-/**
- * Collects text nodes from a shallow-rendered React tree.
- * @param {*} node React node to inspect.
- * @returns {string[]} Flattened text content.
- */
-function collectText(node) {
-  if (typeof node === 'string') return [node];
-  if (!node || !node.props) return [];
-
-  return React.Children.toArray(node.props.children).reduce(
-    (result, child) => result.concat(collectText(child)),
-    [],
-  );
-=======
 function collectText(node) {
   if (typeof node === 'string') {
     return [node];
@@ -148,40 +76,35 @@ function renderHeader(challengeOverrides = {}) {
   );
 
   return renderer.getRenderOutput();
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 }
 
 describe('Challenge detail header actions', () => {
   test('hides registration and submission actions for task challenges', () => {
-<<<<<<< HEAD
-    const renderer = new Renderer();
-
-    renderer.render((
-      <Header
-        {...defaultProps}
-        challenge={{
-          ...defaultProps.challenge,
-          type: 'Task',
-        }}
-      />
-    ));
-
-    const output = renderer.getRenderOutput();
-=======
     const output = renderHeader({
+      phases: [
+        {
+          isOpen: false,
+          name: 'Registration',
+          scheduledEndDate: '2030-01-02T00:00:00.000Z',
+          scheduledStartDate: '2030-01-01T00:00:00.000Z',
+        },
+        {
+          isOpen: true,
+          name: 'Submission',
+          scheduledEndDate: '2030-01-03T00:00:00.000Z',
+          scheduledStartDate: '2030-01-02T00:00:00.000Z',
+        },
+      ],
       task: {
         isTask: true,
       },
       type: 'Task',
     });
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 
     expect(collectText(output)).not.toContain('Register');
     expect(collectText(output)).not.toContain('Unregister');
     expect(collectText(output)).not.toContain('Submit a solution');
   });
-<<<<<<< HEAD
-=======
 
   test('shows registration and submission actions for non-task challenges', () => {
     const output = renderHeader();
@@ -189,5 +112,4 @@ describe('Challenge detail header actions', () => {
     expect(collectText(output)).toContain('Register');
     expect(collectText(output)).toContain('Submit a solution');
   });
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
 });

--- a/__tests__/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/__tests__/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -1,0 +1,47 @@
+import { getDisplayedScores } from '../../../../../../src/shared/components/challenge-detail/MySubmissions/SubmissionsList';
+
+describe('getDisplayedScores', () => {
+  test('uses the initial score as the provisional score before review completes', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: 100,
+        initialScore: 100,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: true,
+            name: 'Registration',
+            scheduledStartDate: '2030-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: null,
+      provisionalScore: 100,
+    });
+  });
+
+  test('shows final scores once the review phase is complete', () => {
+    expect(getDisplayedScores(
+      {
+        finalScore: 100,
+        initialScore: 95,
+        provisionalScore: 0,
+      },
+      {
+        phases: [
+          {
+            isOpen: false,
+            name: 'Review',
+            scheduledStartDate: '2000-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    )).toEqual({
+      finalScore: 100,
+      provisionalScore: 95,
+    });
+  });
+});

--- a/__tests__/shared/utils/mm-review-summations.test.js
+++ b/__tests__/shared/utils/mm-review-summations.test.js
@@ -94,4 +94,35 @@ describe('buildMmSubmissionData', () => {
       }),
     ]);
   });
+
+  it('prefers initial scores over stale provisional scores from raw submissions', () => {
+    const rawSubmissions = [
+      {
+        createdAt: '2026-04-01T00:01:03.000Z',
+        finalScore: 100,
+        id: 'submission-stale-provisional',
+        initialScore: 100,
+        memberId: '1003',
+        provisionalScore: 0,
+        registrant: {
+          memberHandle: 'gamma',
+          memberId: '1003',
+          rating: 1700,
+        },
+        status: 'queued',
+      },
+    ];
+
+    const result = buildMmSubmissionData([], rawSubmissions);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].submissions).toEqual([
+      expect.objectContaining({
+        finalScore: 100,
+        provisionalScore: 100,
+        status: 'queued',
+        submissionId: 'submission-stale-provisional',
+      }),
+    ]);
+  });
 });

--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -148,13 +148,9 @@ export default function ChallengeHeader(props) {
 
   const trackName = getTrackName(track);
   const typeName = getTypeName(type);
-<<<<<<< HEAD
-  const isTaskChallenge = typeName === 'Task';
-=======
   const isTaskChallenge = typeName === 'Task'
     || _.get(challenge, 'task.isTask') === true
     || _.get(challenge, 'legacy.pureV5Task') === true;
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
   const trackLower = trackName ? trackName.replace(' ', '-').toLowerCase() : 'design';
 
   const eventNames = (events || []).map((event => (event.eventName || '').toUpperCase()));
@@ -513,72 +509,7 @@ export default function ChallengeHeader(props) {
                 }
             </div>
             <div styleName="challenge-ops-wrapper">
-<<<<<<< HEAD
               {challengeActions}
-=======
-              {!isTopCrowdChallenge ? (
-                !isTaskChallenge && (
-                  <div styleName="challenge-ops-container">
-                    {hasRegistered ? (
-                      <PrimaryButton
-                        disabled={unregisterButtonDisabled}
-                        theme={{
-                          button: unregisterButtonDisabled
-                            ? style.submitButtonDisabled
-                            : style.submitButton,
-                        }}
-                        forceA
-                        onClick={unregisterFromChallenge}
-                      >
-                        Unregister
-                      </PrimaryButton>
-                    ) : (
-                      <PrimaryButton
-                        disabled={registerButtonDisabled}
-                        theme={{
-                          button: registerButtonDisabled
-                            ? style.submitButtonDisabled
-                            : style.submitButton,
-                        }}
-                        forceA
-                        onClick={registerForChallenge}
-                      >
-                        Register
-                      </PrimaryButton>
-                    )}
-                    <PrimaryButton
-                      disabled={disabled}
-                      theme={{ button: disabled ? style.submitButtonDisabled : style.submitButton }}
-                      to={`${challengesUrl}/${challengeId}/submit`}
-                      forceA
-                    >
-                      <IconsUpload />
-                      <span>Submit a solution</span>
-                    </PrimaryButton>
-                    {
-                      trackName === COMPETITION_TRACKS.DES && hasRegistered && !unregistering
-                        && hasSubmissions && (
-                        <PrimaryButton
-                          theme={{ button: style.submitButton }}
-                          to={`${challengesUrl}/${challengeId}/my-submissions`}
-                        >
-                          View Submissions
-                        </PrimaryButton>
-                      )
-                    }
-                  </div>
-                )
-              ) : (
-                <Link
-                  openNewTab
-                  to={`${topcrowdLink}`}
-                  styleName="topcrowd-container"
-                >
-                  <span>View details on Topcoder platform</span>
-                  <IconsOpenInNew />
-                </Link>
-              )}
->>>>>>> bebcd7d6d3567960f13b1718b6491fb166b23b20
             </div>
           </div>
           <div styleName="deadlines-view">

--- a/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -74,6 +74,36 @@ const getSubmissionCreatedTime = (submission) => {
   );
 };
 
+/**
+ * Returns the scores that should be displayed for a marathon match submission row.
+ * Initial score is the authoritative provisional score for MM submissions, while
+ * final scores should remain hidden until the review phase has completed.
+ *
+ * @param {Object} submission submission attempt shown in My Submissions.
+ * @param {Object} challenge challenge that owns the submission.
+ * @returns {{ finalScore: number|null, provisionalScore: number|null }} display-ready scores.
+ */
+export function getDisplayedScores(submission = {}, challenge = {}) {
+  const toNumericScore = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const isReviewPhaseComplete = _.some(
+    challenge.phases || [],
+    phase => phase.name === 'Review' && !phase.isOpen && moment(phase.scheduledStartDate).isBefore(),
+  );
+
+  const initialScore = toNumericScore(_.get(submission, 'initialScore'));
+  const provisionalScore = toNumericScore(_.get(submission, 'provisionalScore'));
+  const finalScore = toNumericScore(_.get(submission, 'finalScore'));
+
+  return {
+    finalScore: isReviewPhaseComplete ? finalScore : null,
+    provisionalScore: !_.isNil(initialScore) ? initialScore : provisionalScore,
+  };
+}
+
 class SubmissionsListView extends React.Component {
   constructor(props) {
     super(props);
@@ -435,7 +465,7 @@ class SubmissionsListView extends React.Component {
           </div>
           {
             sortedSubmissions.map((mySubmission) => {
-              let { finalScore, provisionalScore } = mySubmission;
+              let { finalScore, provisionalScore } = getDisplayedScores(mySubmission, challenge);
               if (_.isNumber(finalScore)) {
                 if (finalScore > 0) {
                   finalScore = finalScore.toFixed(2);

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -1307,6 +1307,12 @@ function mapStateToProps(state, props) {
               return toNumericScore(match.aggregateScore);
             };
 
+            const initialScore = toNumericScore(normalizedAttempt.initialScore);
+            if (!_.isNil(initialScore)) {
+              normalizedAttempt.initialScore = initialScore;
+              normalizedAttempt.provisionalScore = initialScore;
+            }
+
             const hasProvisionalScore = !_.isNil(normalizedAttempt.provisionalScore);
             const hasFinalScore = !_.isNil(normalizedAttempt.finalScore);
 

--- a/src/shared/utils/mm-review-summations.js
+++ b/src/shared/utils/mm-review-summations.js
@@ -618,7 +618,7 @@ export function buildMmSubmissionData(reviewSummations = [], rawSubmissions = []
     const timestamp = getSubmissionTimestamp(submission);
     const timestampValue = toTimestampValue(timestamp);
     const provisionalScore = normalizeScoreValue(
-      _.get(submission, 'provisionalScore', _.get(submission, 'initialScore')),
+      _.get(submission, 'initialScore', _.get(submission, 'provisionalScore')),
     );
     const finalScore = normalizeScoreValue(_.get(submission, 'finalScore'));
     const isLatest = _.isNil(submission.isLatest)


### PR DESCRIPTION
What was broken
- Marathon Match provisional scores were showing under Final Score in My Submissions before review was complete.
- The public Submissions tab could show stale provisional scores of 0 even when the scored attempt was 100.
- The develop baseline also contained committed header conflict markers that prevented the required Jest/build validation from completing.

Root cause
- The MM normalization path preferred raw provisionalScore values over initialScore, even when provisionalScore was stale.
- My Submissions rendered finalScore directly instead of treating the review phase as the point when final scores become visible.
- Header source and test files still contained unresolved conflict blocks on this base branch.

What was changed
- Prefer initialScore when normalizing MM provisional scores from raw submissions and normalized attempts.
- Added a display helper in My Submissions so provisional scores come from the initial score and final scores stay hidden until review completes.
- Resolved the committed header conflict blocks while keeping the current action rendering path and task detection consistent for the full suite.

Any added/updated tests
- Added a regression test for stale MM provisional scores in mm-review-summations.
- Added My Submissions display tests covering pre-review and post-review score rendering.
- Updated the challenge-detail header action test fixture so the full Jest suite runs cleanly on this branch.
