### PR TITLE
PM-4648: normalize task visibility for work app tasks

### DIFF
--- a/__tests__/shared/components/challenge-detail/Header/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Header/index.jsx
@@ -118,6 +118,16 @@ describe('Challenge detail header actions', () => {
     expect(collectText(output)).not.toContain('Submit a solution');
   });
 
+  test('hides registration and submission actions for flattened task payloads', () => {
+    const output = renderHeader({
+      taskIsTask: true,
+    });
+
+    expect(collectText(output)).not.toContain('Register');
+    expect(collectText(output)).not.toContain('Unregister');
+    expect(collectText(output)).not.toContain('Submit a solution');
+  });
+
   test('shows registration and submission actions for non-task challenges', () => {
     const output = renderHeader();
 

--- a/__tests__/shared/components/challenge-listing/Listing/Bucket.jsx
+++ b/__tests__/shared/components/challenge-listing/Listing/Bucket.jsx
@@ -191,6 +191,49 @@ test('Hides assigned task when memberId and userId do not match', () => {
   expect(countElementsByType(renderer.getRenderOutput(), ChallengeCard)).toBe(0);
 });
 
+test('Hides assigned task when flattened task fields and userId do not match', () => {
+  const renderer = new Renderer();
+  renderer.render((
+    <Bucket
+      activeBucket="openForRegistration"
+      auth={{ user: { roles: [] } }}
+      bucket="openForRegistration"
+      challenges={[
+        {
+          id: 'task-3',
+          name: 'Assigned task',
+          status: 'ACTIVE',
+          type: { name: 'Task' },
+          tags: [],
+          prizes: [],
+          taskIsTask: true,
+          taskIsAssigned: true,
+          taskMemberId: 'owner-user',
+        },
+      ]}
+      challengeTypes={challengeTypes}
+      challengesUrl="/challenges"
+      expand={_.noop}
+      expanded
+      expandTag={_.noop}
+      expandedTags={[]}
+      expanding={false}
+      filterState={{}}
+      isLoggedIn
+      needLoad={false}
+      prizeMode="money-usd"
+      selectChallengeDetailsTab={_.noop}
+      setFilterState={setFilterState}
+      setSearchText={setSearchText}
+      setSort={setSort}
+      sort=""
+      userId="different-user"
+    />
+  ));
+
+  expect(countElementsByType(renderer.getRenderOutput(), ChallengeCard)).toBe(0);
+});
+
 // class Wrapper extends React.Component {
 //   componentDidMount() {}
 

--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -8,7 +8,12 @@
 import _ from 'lodash';
 import moment from 'moment';
 import 'moment-duration-format';
-import { isMM, getTrackName, getTypeName } from 'utils/challenge';
+import {
+  isMM,
+  getTaskInfo,
+  getTrackName,
+  getTypeName,
+} from 'utils/challenge';
 
 import PT from 'prop-types';
 import React, { useMemo } from 'react';
@@ -148,9 +153,7 @@ export default function ChallengeHeader(props) {
 
   const trackName = getTrackName(track);
   const typeName = getTypeName(type);
-  const isTaskChallenge = typeName === 'Task'
-    || _.get(challenge, 'task.isTask') === true
-    || _.get(challenge, 'legacy.pureV5Task') === true;
+  const { isTask: isTaskChallenge } = getTaskInfo(challenge);
   const trackLower = trackName ? trackName.replace(' ', '-').toLowerCase() : 'design';
 
   const eventNames = (events || []).map((event => (event.eventName || '').toUpperCase()));

--- a/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
@@ -16,7 +16,7 @@ import {
 import SortingSelectBar from 'components/SortingSelectBar';
 import Waypoint from 'react-waypoint';
 // import { challenge as challengeUtils } from 'topcoder-react-lib';
-import { getTypeName } from 'utils/challenge';
+import { getTaskInfo, getTypeName } from 'utils/challenge';
 import CardPlaceholder from '../../placeholders/ChallengeCard';
 import ChallengeCard from '../../ChallengeCard';
 import NoRecommenderChallengeCard from '../../NoRecommenderChallengeCard';
@@ -86,12 +86,10 @@ export default function Bucket({
 
   if (!_.includes(roles, 'administrator')) {
     filteredChallenges = sortedChallenges.filter((ch) => {
-      const typeName = getTypeName(ch);
-      if (typeName === 'Task'
-        && ch.task
-        && ch.task.isTask
-        && ch.task.isAssigned
-        && `${ch.task.memberId}` !== `${userId}`) {
+      const taskInfo = getTaskInfo(ch);
+      if (taskInfo.isTask
+        && taskInfo.isAssigned
+        && `${taskInfo.memberId}` !== `${userId}`) {
         return null;
       }
       return ch;

--- a/src/shared/utils/challenge.js
+++ b/src/shared/utils/challenge.js
@@ -30,6 +30,28 @@ export function getTypeName(typeOrChallenge) {
 }
 
 /**
+ * Returns normalized task info for challenge payloads that may use nested
+ * or flattened task fields.
+ * @param {Object} challenge challenge object
+ * @returns {{isTask: boolean, isAssigned: boolean, memberId: ?string}}
+ */
+export function getTaskInfo(challenge = {}) {
+  const taskIsTask = _.get(challenge, 'task.isTask');
+  const taskIsAssigned = _.get(challenge, 'task.isAssigned');
+  const taskMemberId = _.get(challenge, 'task.memberId');
+
+  return {
+    isTask: getTypeName(challenge) === 'Task'
+      || (_.isNil(taskIsTask) ? _.get(challenge, 'taskIsTask', false) : taskIsTask)
+      || _.get(challenge, 'legacy.pureV5Task') === true,
+    isAssigned: _.isNil(taskIsAssigned)
+      ? _.get(challenge, 'taskIsAssigned', false)
+      : taskIsAssigned,
+    memberId: !_.isNil(taskMemberId) ? taskMemberId : _.get(challenge, 'taskMemberId', null),
+  };
+}
+
+/**
  * check if is marathon match challenge
  * @param {Object} challenge challenge object
  */
@@ -70,4 +92,5 @@ export default {
   updateChallengeType,
   getTrackName,
   getTypeName,
+  getTaskInfo,
 };


### PR DESCRIPTION
What was broken
Task challenges created from the work app could still show registration, unregistration, and submission controls in the challenge header. Assigned task cards could also remain visible in listings for users who were not the assignee when the payload used flattened task fields.

Root cause
The UI only normalized task state in some places. Header logic and listing filters depended on nested task fields or partial task detection, while work-app task payloads can expose task flags as flattened taskIsTask, taskIsAssigned, and taskMemberId fields.

What was changed
Added a shared getTaskInfo helper in utils/challenge to normalize task detection and assignment data across nested, flattened, and legacy task payloads.
Updated the challenge detail header to use the normalized task info when deciding whether task-only actions should be hidden.
Updated the listing bucket filter to hide assigned tasks for non-assigned users when the task payload uses flattened fields.

Any added/updated tests
Added header coverage for flattened task payloads to confirm task actions stay hidden.
Added bucket coverage for flattened assigned-task payloads to confirm non-assigned users do not see those cards.
