### PR TITLE
PM-4662: harden MM provisional score display

### DIFF
--- a/__tests__/shared/components/challenge-detail/Header/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Header/index.jsx
@@ -118,6 +118,16 @@ describe('Challenge detail header actions', () => {
     expect(collectText(output)).not.toContain('Submit a solution');
   });
 
+  test('hides registration and submission actions for flattened task payloads', () => {
+    const output = renderHeader({
+      taskIsTask: true,
+    });
+
+    expect(collectText(output)).not.toContain('Register');
+    expect(collectText(output)).not.toContain('Unregister');
+    expect(collectText(output)).not.toContain('Submit a solution');
+  });
+
   test('shows registration and submission actions for non-task challenges', () => {
     const output = renderHeader();
 

--- a/__tests__/shared/components/challenge-detail/Submissions/score-display.js
+++ b/__tests__/shared/components/challenge-detail/Submissions/score-display.js
@@ -1,0 +1,24 @@
+import { getDisplayedMmScores } from '../../../../../src/shared/components/challenge-detail/Submissions/score-display';
+
+describe('getDisplayedMmScores', () => {
+  test('prefers initial score over a stale provisional score', () => {
+    expect(getDisplayedMmScores({
+      finalScore: 100,
+      initialScore: 100,
+      provisionalScore: 0,
+    })).toEqual({
+      finalScore: 100,
+      provisionalScore: 100,
+    });
+  });
+
+  test('falls back to provisional score when initial score is unavailable', () => {
+    expect(getDisplayedMmScores({
+      finalScore: '95.25',
+      provisionalScore: '94.5',
+    })).toEqual({
+      finalScore: 95.25,
+      provisionalScore: 94.5,
+    });
+  });
+});

--- a/__tests__/shared/components/challenge-listing/Listing/Bucket.jsx
+++ b/__tests__/shared/components/challenge-listing/Listing/Bucket.jsx
@@ -191,6 +191,49 @@ test('Hides assigned task when memberId and userId do not match', () => {
   expect(countElementsByType(renderer.getRenderOutput(), ChallengeCard)).toBe(0);
 });
 
+test('Hides assigned task when flattened task fields and userId do not match', () => {
+  const renderer = new Renderer();
+  renderer.render((
+    <Bucket
+      activeBucket="openForRegistration"
+      auth={{ user: { roles: [] } }}
+      bucket="openForRegistration"
+      challenges={[
+        {
+          id: 'task-3',
+          name: 'Assigned task',
+          status: 'ACTIVE',
+          type: { name: 'Task' },
+          tags: [],
+          prizes: [],
+          taskIsTask: true,
+          taskIsAssigned: true,
+          taskMemberId: 'owner-user',
+        },
+      ]}
+      challengeTypes={challengeTypes}
+      challengesUrl="/challenges"
+      expand={_.noop}
+      expanded
+      expandTag={_.noop}
+      expandedTags={[]}
+      expanding={false}
+      filterState={{}}
+      isLoggedIn
+      needLoad={false}
+      prizeMode="money-usd"
+      selectChallengeDetailsTab={_.noop}
+      setFilterState={setFilterState}
+      setSearchText={setSearchText}
+      setSort={setSort}
+      sort=""
+      userId="different-user"
+    />
+  ));
+
+  expect(countElementsByType(renderer.getRenderOutput(), ChallengeCard)).toBe(0);
+});
+
 // class Wrapper extends React.Component {
 //   componentDidMount() {}
 

--- a/src/shared/components/challenge-detail/Header/index.jsx
+++ b/src/shared/components/challenge-detail/Header/index.jsx
@@ -8,7 +8,12 @@
 import _ from 'lodash';
 import moment from 'moment';
 import 'moment-duration-format';
-import { isMM, getTrackName, getTypeName } from 'utils/challenge';
+import {
+  isMM,
+  getTaskInfo,
+  getTrackName,
+  getTypeName,
+} from 'utils/challenge';
 
 import PT from 'prop-types';
 import React, { useMemo } from 'react';
@@ -148,9 +153,7 @@ export default function ChallengeHeader(props) {
 
   const trackName = getTrackName(track);
   const typeName = getTypeName(type);
-  const isTaskChallenge = typeName === 'Task'
-    || _.get(challenge, 'task.isTask') === true
-    || _.get(challenge, 'legacy.pureV5Task') === true;
+  const { isTask: isTaskChallenge } = getTaskInfo(challenge);
   const trackLower = trackName ? trackName.replace(' ', '-').toLowerCase() : 'design';
 
   const eventNames = (events || []).map((event => (event.eventName || '').toUpperCase()));

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/SubmissionHistoryRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/SubmissionHistoryRow/index.jsx
@@ -14,6 +14,7 @@ import FailedSubmissionTooltip from '../../FailedSubmissionTooltip';
 import InReview from '../../../icons/in-review.svg';
 import Queued from '../../../icons/queued.svg';
 import DownloadIcon from '../../../../SubmissionManagement/Icons/IconSquareDownload.svg';
+import { getDisplayedMmScores } from '../../score-display';
 
 import './style.scss';
 
@@ -24,6 +25,7 @@ export default function SubmissionHistoryRow({
   isRDM,
   submission,
   finalScore,
+  initialScore,
   provisionalScore,
   submissionTime,
   createdAt,
@@ -37,12 +39,14 @@ export default function SubmissionHistoryRow({
 }) {
   // todo: hide download button until update submissions API
   const hideDownloadForMMRDM = true;
-  const parseScore = (value) => {
-    const numeric = Number(value);
-    return Number.isFinite(numeric) ? numeric : null;
-  };
-  const provisionalScoreValue = parseScore(provisionalScore);
-  const finalScoreValue = parseScore(finalScore);
+  const {
+    provisionalScore: provisionalScoreValue,
+    finalScore: finalScoreValue,
+  } = getDisplayedMmScores({
+    finalScore,
+    initialScore,
+    provisionalScore,
+  });
 
   const timeField = isMM ? submissionTime : createdAt;
   const submissionMoment = timeField ? moment(timeField) : null;
@@ -138,6 +142,7 @@ export default function SubmissionHistoryRow({
 
 SubmissionHistoryRow.defaultProps = {
   finalScore: null,
+  initialScore: null,
   provisionalScore: null,
   isReviewPhaseComplete: false,
   isLoggedIn: false,
@@ -150,6 +155,11 @@ SubmissionHistoryRow.propTypes = {
   isRDM: PT.bool.isRequired,
   submission: PT.number.isRequired,
   finalScore: PT.oneOfType([
+    PT.number,
+    PT.string,
+    PT.oneOf([null]),
+  ]),
+  initialScore: PT.oneOfType([
     PT.number,
     PT.string,
     PT.oneOf([null]),

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
@@ -14,6 +14,7 @@ import moment from 'moment';
 import FailedSubmissionTooltip from '../FailedSubmissionTooltip';
 import InReview from '../../icons/in-review.svg';
 import Queued from '../../icons/queued.svg';
+import { getDisplayedMmScores } from '../score-display';
 import SubmissionHistoryRow from './SubmissionHistoryRow';
 
 import style from './style.scss';
@@ -31,7 +32,6 @@ export default function SubmissionRow({
     created,
     createdAt,
     initialScore,
-    finalScore: submissionFinalScore,
   } = latestSubmission;
 
   const parseScore = (value) => {
@@ -42,8 +42,7 @@ export default function SubmissionRow({
   // For non-MM challenges, use createdAt field for submission date
   const submissionDateField = isMM ? submissionTime : (created || createdAt);
 
-  const provisionalScore = parseScore(_.get(latestSubmission, 'provisionalScore'));
-  const finalScore = parseScore(submissionFinalScore);
+  const { provisionalScore, finalScore } = getDisplayedMmScores(latestSubmission);
   const initialScoreValue = parseScore(initialScore);
 
   const getInitialReviewResult = () => {

--- a/src/shared/components/challenge-detail/Submissions/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/index.jsx
@@ -33,11 +33,12 @@ import ViewAsListActive from '../icons/view-as-list-active.svg';
 import ViewAsListInactive from '../icons/view-as-list-inactive.svg';
 import ViewAsTableActive from '../icons/view-as-table-active.svg';
 import ViewAsTableInactive from '../icons/view-as-table-inactive.svg';
+import { getDisplayedMmScores } from './score-display';
 import SubmissionRow from './SubmissionRow';
 import SubmissionInformationModal from './SubmissionInformationModal';
 import style from './style.scss';
 
-const { getProvisionalScore, getFinalScore } = submissionUtils;
+const { getFinalScore } = submissionUtils;
 
 const { getService } = services.submissions;
 
@@ -383,8 +384,8 @@ class SubmissionsComponent extends React.Component {
           break;
         }
         case 'Provisional Score': {
-          valueA = toScoreValue(getProvisionalScore(primaryA));
-          valueB = toScoreValue(getProvisionalScore(primaryB));
+          valueA = getDisplayedMmScores(primaryA).provisionalScore;
+          valueB = getDisplayedMmScores(primaryB).provisionalScore;
           break;
         }
         default:

--- a/src/shared/components/challenge-detail/Submissions/score-display.js
+++ b/src/shared/components/challenge-detail/Submissions/score-display.js
@@ -1,0 +1,31 @@
+/**
+ * Parses a submission score into a finite numeric value.
+ *
+ * @param {*} value raw score candidate from the API payload.
+ * @returns {number|null} finite score value when present, otherwise null.
+ */
+function toNumericScore(value) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+/**
+ * Resolves the authoritative MM scores for submissions tab rendering.
+ * MM provisional score should come from the initial score whenever it exists,
+ * because raw provisionalScore values can be stale during queued review updates.
+ *
+ * @param {Object} submission submission attempt payload.
+ * @returns {{ finalScore: number|null, provisionalScore: number|null }} normalized MM scores.
+ */
+export function getDisplayedMmScores(submission = {}) {
+  const initialScore = toNumericScore(submission.initialScore);
+  const provisionalScore = toNumericScore(submission.provisionalScore);
+  const finalScore = toNumericScore(submission.finalScore);
+
+  return {
+    finalScore,
+    provisionalScore: initialScore !== null ? initialScore : provisionalScore,
+  };
+}
+
+export default getDisplayedMmScores;

--- a/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
+++ b/src/shared/components/challenge-listing/Listing/Bucket/index.jsx
@@ -16,7 +16,7 @@ import {
 import SortingSelectBar from 'components/SortingSelectBar';
 import Waypoint from 'react-waypoint';
 // import { challenge as challengeUtils } from 'topcoder-react-lib';
-import { getTypeName } from 'utils/challenge';
+import { getTaskInfo, getTypeName } from 'utils/challenge';
 import CardPlaceholder from '../../placeholders/ChallengeCard';
 import ChallengeCard from '../../ChallengeCard';
 import NoRecommenderChallengeCard from '../../NoRecommenderChallengeCard';
@@ -86,12 +86,10 @@ export default function Bucket({
 
   if (!_.includes(roles, 'administrator')) {
     filteredChallenges = sortedChallenges.filter((ch) => {
-      const typeName = getTypeName(ch);
-      if (typeName === 'Task'
-        && ch.task
-        && ch.task.isTask
-        && ch.task.isAssigned
-        && `${ch.task.memberId}` !== `${userId}`) {
+      const taskInfo = getTaskInfo(ch);
+      if (taskInfo.isTask
+        && taskInfo.isAssigned
+        && `${taskInfo.memberId}` !== `${userId}`) {
         return null;
       }
       return ch;

--- a/src/shared/utils/challenge.js
+++ b/src/shared/utils/challenge.js
@@ -30,6 +30,28 @@ export function getTypeName(typeOrChallenge) {
 }
 
 /**
+ * Returns normalized task info for challenge payloads that may use nested
+ * or flattened task fields.
+ * @param {Object} challenge challenge object
+ * @returns {{isTask: boolean, isAssigned: boolean, memberId: ?string}}
+ */
+export function getTaskInfo(challenge = {}) {
+  const taskIsTask = _.get(challenge, 'task.isTask');
+  const taskIsAssigned = _.get(challenge, 'task.isAssigned');
+  const taskMemberId = _.get(challenge, 'task.memberId');
+
+  return {
+    isTask: getTypeName(challenge) === 'Task'
+      || (_.isNil(taskIsTask) ? _.get(challenge, 'taskIsTask', false) : taskIsTask)
+      || _.get(challenge, 'legacy.pureV5Task') === true,
+    isAssigned: _.isNil(taskIsAssigned)
+      ? _.get(challenge, 'taskIsAssigned', false)
+      : taskIsAssigned,
+    memberId: !_.isNil(taskMemberId) ? taskMemberId : _.get(challenge, 'taskMemberId', null),
+  };
+}
+
+/**
  * check if is marathon match challenge
  * @param {Object} challenge challenge object
  */
@@ -70,4 +92,5 @@ export default {
   updateChallengeType,
   getTrackName,
   getTypeName,
+  getTaskInfo,
 };


### PR DESCRIPTION
What was broken
- The Marathon Match Submissions tab could still show stale provisional scores of 0 instead of the scored attempt value.
- Submission history rows could surface the same stale provisional score when initial score data was present.

Root cause
- The Submissions rendering and provisional-score sorting path still treated raw provisionalScore as authoritative.
- Some MM payloads carry the correct score in initialScore while provisionalScore remains stale during queued review updates.

What was changed
- Added a shared MM score-display helper that prefers initialScore when it is available.
- Reused that helper in the Submissions table sorting, submission rows, and submission history rows so the UI stays aligned.

Any added/updated tests
- Added regression tests for stale MM provisional scores in the Submissions score-display helper.
- Added fallback coverage for payloads that only provide provisionalScore.
