### PR TITLE
PM-5319: Restrict submission uploads to local files

### DIFF
--- a/__tests__/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
+++ b/__tests__/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
@@ -1,0 +1,70 @@
+import { shallow } from 'enzyme';
+import { client as filestack } from 'filestack-react';
+import React from 'react';
+
+import FilestackFilePicker from 'components/SubmissionPage/FilestackFilePicker';
+
+jest.mock('filestack-react', () => ({
+  client: {
+    init: jest.fn(),
+  },
+}));
+
+describe('FilestackFilePicker', () => {
+  let open;
+  let picker;
+  let props;
+
+  beforeEach(() => {
+    open = jest.fn();
+    picker = jest.fn(() => ({ open }));
+    filestack.init.mockReturnValue({
+      picker,
+      upload: jest.fn(),
+    });
+    props = {
+      userId: '123456',
+      challengeId: 'challenge-1',
+      fileName: '',
+      fileExtensions: ['.zip'],
+      title: 'Upload submission',
+      setError: jest.fn(),
+      setFileName: jest.fn(),
+      setUploadProgress: jest.fn(),
+      dragged: false,
+      setDragged: jest.fn(),
+      setFilestackData: jest.fn(),
+    };
+  });
+
+  test('opens standard challenge uploads from the local file system only', () => {
+    const wrapper = shallow(<FilestackFilePicker {...props} />);
+
+    wrapper.find('[aria-label="Select file to upload"]').prop('onClick')();
+
+    expect(picker).toHaveBeenCalledTimes(1);
+    expect(picker.mock.calls[0][0].fromSources).toEqual(['local_file_system']);
+    expect(picker.mock.calls[0][0].accept).toEqual(['.zip']);
+    expect(open).toHaveBeenCalledTimes(1);
+  });
+
+  test('keeps Topgear URL submissions available', () => {
+    const inputUrl = 'https://wipro365.sharepoint.com/sites/project/deliverable.docx';
+    const wrapper = shallow((
+      <FilestackFilePicker
+        {...props}
+        isChallengeBelongToTopgearGroup
+      />
+    ));
+
+    wrapper.setState({ inputUrl });
+    wrapper.instance().onClickPick();
+
+    expect(picker).not.toHaveBeenCalled();
+    expect(props.setFilestackData).toHaveBeenCalledWith(expect.objectContaining({
+      fileType: 'url',
+      fileUrl: inputUrl,
+      filename: 'deliverable.docx',
+    }));
+  });
+});

--- a/src/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
+++ b/src/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
@@ -22,6 +22,8 @@ import style from './styles.scss';
 
 const { fireErrorMessage } = errors;
 
+const SUBMISSION_PICKER_SOURCES = ['local_file_system'];
+
 /**
  * FilestackFilePicker component
  */
@@ -237,14 +239,7 @@ class FilestackFilePicker extends React.Component {
                 const path = this.generateFilePath();
                 this.filestack.picker({
                   accept: fileExtensions,
-                  fromSources: [
-                    'local_file_system',
-                    'googledrive',
-                    'dropbox',
-                    'onedrive',
-                    'github',
-                    'url',
-                  ],
+                  fromSources: SUBMISSION_PICKER_SOURCES,
                   maxSize: 500 * 1024 * 1024,
                   onFileUploadFailed: () => setDragged(false),
                   onFileUploadFinished: (file) => {
@@ -263,14 +258,7 @@ class FilestackFilePicker extends React.Component {
                 const path = this.generateFilePath();
                 this.filestack.picker({
                   accept: fileExtensions,
-                  fromSources: [
-                    'local_file_system',
-                    'googledrive',
-                    'dropbox',
-                    'onedrive',
-                    'github',
-                    'url',
-                  ],
+                  fromSources: SUBMISSION_PICKER_SOURCES,
                   maxSize: 500 * 1024 * 1024,
                   onFileUploadFailed: () => setDragged(false),
                   onFileUploadFinished: (file) => {


### PR DESCRIPTION
What was broken

The challenge submission Filestack picker exposed external import sources such as Google Drive, Dropbox, OneDrive, GitHub, and direct URL for standard submissions.

Root cause (if identifiable)

The non-Topgear picker configuration explicitly allowed every Filestack source even though only uploaded files can go through the expected file handling path.

What was changed

Restricted the standard submission picker source list to local file uploads while leaving the existing Topgear URL submission path intact.

Any added/updated tests

Added FilestackFilePicker coverage to assert standard submissions open Filestack with only the local file system source and Topgear URL submissions still populate URL submission data.

Validation

- npm run jest -- __tests__/shared/components/SubmissionPage/FilestackFilePicker/index.jsx
- npm run lint
- npm test
- npm run build
