### PR TITLE
PM-5393: Restrict challenge type filters

### DIFF
--- a/__tests__/shared/utils/challenge-listing/constants.test.js
+++ b/__tests__/shared/utils/challenge-listing/constants.test.js
@@ -1,0 +1,38 @@
+import {
+  getVisibleChallengeTypes,
+  sanitizeChallengeTypeFilter,
+} from 'utils/challenge-listing/constants';
+
+describe('challenge listing constants', () => {
+  test('returns only the supported challenge types once and in filter order', () => {
+    const challengeTypes = [
+      { name: 'AI', abbreviation: 'AI' },
+      { name: 'AI Engineering', abbreviation: 'AIENG' },
+      { name: 'Marathon Match', abbreviation: 'MM' },
+      { name: 'Challenge', abbreviation: 'CH' },
+      { name: 'Marathon Match', abbreviation: 'MM' },
+      { name: 'Task', abbreviation: 'TSK' },
+      { name: 'First2Finish', abbreviation: 'F2F' },
+      { name: 'type-1778748614529', abbreviation: 'type-1778748614529' },
+    ];
+
+    expect(getVisibleChallengeTypes(challengeTypes)).toEqual([
+      { name: 'Challenge', abbreviation: 'CH' },
+      { name: 'First2Finish', abbreviation: 'F2F' },
+      { name: 'Marathon Match', abbreviation: 'MM' },
+      { name: 'Task', abbreviation: 'TSK' },
+    ]);
+  });
+
+  test('removes hidden and duplicated selected challenge type filters', () => {
+    expect(sanitizeChallengeTypeFilter([
+      'AI',
+      'CH',
+      'F2F',
+      'MM',
+      'MM',
+      'TSK',
+      'type-1778748614529',
+    ])).toEqual(['CH', 'F2F', 'MM', 'TSK']);
+  });
+});

--- a/src/shared/containers/challenge-listing/FilterPanel.jsx
+++ b/src/shared/containers/challenge-listing/FilterPanel.jsx
@@ -17,7 +17,10 @@ import { connect } from 'react-redux';
 import qs from 'qs';
 import _ from 'lodash';
 import { createStaticRanges } from 'utils/challenge-listing/date-range';
-import { EXCLUDED_CHALLENGE_TYPE_NAMES } from 'utils/challenge-listing/constants';
+import {
+  getVisibleChallengeTypes,
+  sanitizeChallengeTypeFilter,
+} from 'utils/challenge-listing/constants';
 
 const MIN = 60 * 1000;
 
@@ -74,7 +77,9 @@ export class Container extends React.Component {
       query.customDate = customDate;
     }
 
-    if (query.types && query.types.length) {
+    if (query.types && sanitizeChallengeTypeFilter(
+      Array.isArray(query.types) ? query.types : [query.types],
+    ).length) {
       this.initialDefaultChallengeTypes = true;
     }
 
@@ -105,8 +110,7 @@ export class Container extends React.Component {
       });
       this.initialDefaultChallengeTypes = true;
     } else if (validTypes.length && currentTypes.length) {
-      const validAbbreviations = validTypes.map(item => item.abbreviation);
-      const sanitizedTypes = currentTypes.filter(type => validAbbreviations.includes(type));
+      const sanitizedTypes = sanitizeChallengeTypeFilter(currentTypes);
       if (sanitizedTypes.length !== currentTypes.length) {
         if (!sanitizedTypes.length) {
           this.initialDefaultChallengeTypes = false;
@@ -235,16 +239,11 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
   const cl = state.challengeListing;
   const tc = state.tcCommunities;
-  const filteredChallengeTypes = cl.challengeTypes
-    .filter(type => !EXCLUDED_CHALLENGE_TYPE_NAMES.includes(type.name));
-  const excludedTypeAbbreviations = cl.challengeTypes
-    .filter(type => EXCLUDED_CHALLENGE_TYPE_NAMES.includes(type.name))
-    .map(type => type.abbreviation);
+  const filteredChallengeTypes = getVisibleChallengeTypes(cl.challengeTypes);
   let filterState = cl.filter;
   const existingTypes = Array.isArray(cl.filter.types) ? cl.filter.types : [];
-  if (excludedTypeAbbreviations.length && existingTypes.length) {
-    const sanitizedTypes = existingTypes
-      .filter(type => !excludedTypeAbbreviations.includes(type));
+  if (existingTypes.length) {
+    const sanitizedTypes = sanitizeChallengeTypeFilter(existingTypes);
     if (sanitizedTypes.length !== existingTypes.length) {
       filterState = {
         ...cl.filter,

--- a/src/shared/reducers/challenge-listing/index.js
+++ b/src/shared/reducers/challenge-listing/index.js
@@ -15,7 +15,7 @@ import {
   actions as actionsUtils,
 } from 'topcoder-react-lib';
 import { REVIEW_OPPORTUNITY_TYPES } from 'utils/tc';
-import { EXCLUDED_CHALLENGE_TYPE_NAMES } from 'utils/challenge-listing/constants';
+import { sanitizeChallengeTypeFilter } from 'utils/challenge-listing/constants';
 import filterPanel from './filter-panel';
 import sidebar, { factory as sidebarFactory } from './sidebar';
 
@@ -408,12 +408,8 @@ function onSetFilter(state, { payload }) {
    * do it very carefuly (many params are not validated). */
   const basePayload = _.isPlainObject(payload) ? payload : {};
   const sanitizedPayload = { ...basePayload };
-  const excludedTypeAbbreviations = state.challengeTypes
-    .filter(type => EXCLUDED_CHALLENGE_TYPE_NAMES.includes(type.name))
-    .map(type => type.abbreviation);
-  if (excludedTypeAbbreviations.length && Array.isArray(basePayload.types)) {
-    sanitizedPayload.types = basePayload.types
-      .filter(type => !excludedTypeAbbreviations.includes(type));
+  if (Array.isArray(basePayload.types)) {
+    sanitizedPayload.types = sanitizeChallengeTypeFilter(basePayload.types);
   }
   const filter = _.pickBy(_.pick(
     sanitizedPayload,

--- a/src/shared/utils/challenge-listing/constants.js
+++ b/src/shared/utils/challenge-listing/constants.js
@@ -1,4 +1,71 @@
-const EXCLUDED_CHALLENGE_TYPE_NAMES = ['Topgear Task'];
+const VISIBLE_CHALLENGE_TYPES = [
+  {
+    name: 'Challenge',
+    abbreviation: 'CH',
+  },
+  {
+    name: 'First2Finish',
+    abbreviation: 'F2F',
+  },
+  {
+    name: 'Marathon Match',
+    abbreviation: 'MM',
+  },
+  {
+    name: 'Task',
+    abbreviation: 'TSK',
+  },
+];
 
-export { EXCLUDED_CHALLENGE_TYPE_NAMES };
-export default EXCLUDED_CHALLENGE_TYPE_NAMES;
+const VISIBLE_CHALLENGE_TYPE_ABBREVIATIONS = VISIBLE_CHALLENGE_TYPES
+  .map(type => type.abbreviation);
+
+/**
+ * Returns the challenge types that should be displayed in listing filters.
+ *
+ * @param {Array<Object>} challengeTypes Challenge type records loaded from the
+ * challenge API.
+ * @return {Array<Object>} One API challenge type record per visible type, in
+ * the order used by the filter panel.
+ */
+function getVisibleChallengeTypes(challengeTypes = []) {
+  if (!Array.isArray(challengeTypes)) {
+    return [];
+  }
+
+  return VISIBLE_CHALLENGE_TYPES
+    .map(visibleType => (
+      challengeTypes.find(type => (
+        type.name === visibleType.name
+        && type.abbreviation === visibleType.abbreviation
+      ))
+      || challengeTypes.find(type => type.name === visibleType.name)
+    ))
+    .filter(Boolean);
+}
+
+/**
+ * Removes hidden and duplicated challenge type filter values.
+ *
+ * @param {Array<String>} types Selected challenge type abbreviations.
+ * @return {Array<String>} Selected abbreviations limited to the visible filter
+ * types.
+ */
+function sanitizeChallengeTypeFilter(types = []) {
+  if (!Array.isArray(types)) {
+    return types;
+  }
+
+  return types.filter((type, index) => (
+    VISIBLE_CHALLENGE_TYPE_ABBREVIATIONS.includes(type)
+    && types.indexOf(type) === index
+  ));
+}
+
+export {
+  VISIBLE_CHALLENGE_TYPES,
+  VISIBLE_CHALLENGE_TYPE_ABBREVIATIONS,
+  getVisibleChallengeTypes,
+  sanitizeChallengeTypeFilter,
+};
+export default VISIBLE_CHALLENGE_TYPES;


### PR DESCRIPTION
What was broken
The community challenge listing Type filter displayed unsupported challenge types such as AI, AI Engineering, generated test types, and duplicate Marathon Match entries.

Root cause
The filter panel rendered the raw challenge type list returned by the API, with only a single excluded type name. New, duplicated, or generated API type records were therefore exposed as listing filters and could remain in the selected type query state.

What was changed
Added a visible challenge type whitelist for Challenge, First2Finish, Marathon Match, and Task. The filter panel now derives visible types from that whitelist, keeps the expected order, removes duplicate type records, and sanitizes selected type values before updating filter state or query handling.

Any added/updated tests
Added unit coverage for visible challenge type derivation and selected type sanitization, including AI, AI Engineering, generated type values, and duplicate Marathon Match values.
