### PR TITLE
PM-5416: Indent markdown challenge spec lists

### DIFF
--- a/src/shared/components/challenge-detail/Specification/SpecificationComponent/styles.scss
+++ b/src/shared/components/challenge-detail/Specification/SpecificationComponent/styles.scss
@@ -2,6 +2,11 @@
 
 .container {
   :global {
+    ul,
+    ol {
+      padding-left: 20px;
+    }
+
     table {
       display: block;
       width: 100%;


### PR DESCRIPTION
What was broken
Markdown-rendered bullet and numbered lists in challenge specifications sat too close to the left edge, making list content look cramped.

Root cause (if identifiable)
The markdown specification component only provided custom table styling and did not add list indentation after the app's global/list reset styles.

What was changed
Added scoped left padding for ordered and unordered lists inside the challenge specification markdown renderer.

Any added/updated tests
No automated tests were added because this is a visual CSS-only spacing change and the existing Jest setup does not assert compiled SCSS layout. Validated with npm run lint, npm test, and npm run build.
