### PR TITLE
PM-5496: Force login for grouped challenge details

### DIFF
--- a/__tests__/shared/containers/challenge-detail/index.jsx
+++ b/__tests__/shared/containers/challenge-detail/index.jsx
@@ -1,4 +1,12 @@
-import { getDisplayWinners, isWiproRegistrationBlocked } from 'containers/challenge-detail';
+import {
+  buildChallengeLoginUrl,
+  getDisplayWinners,
+  isGroupedChallenge,
+  isGroupedChallengeAccessError,
+  isWiproRegistrationBlocked,
+  shouldLoginForGroupedChallenge,
+  shouldLoginForGroupedChallengeError,
+} from 'containers/challenge-detail';
 
 describe('Challenge detail Wipro registration guard', () => {
   test('blocks Wipro members when challenge disallows Wipro participation', () => {
@@ -65,5 +73,48 @@ describe('Challenge detail winners filter', () => {
     expect(winners).toEqual([
       { handle: 'taskWinner', type: 'provisional' },
     ]);
+  });
+});
+
+describe('Challenge detail grouped challenge login guard', () => {
+  beforeEach(() => {
+    document.cookie = 'tc_utm=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+  });
+
+  test('detects grouped challenge payloads from array or map groups', () => {
+    expect(isGroupedChallenge({ groups: ['group-id'] })).toBe(true);
+    expect(isGroupedChallenge({ groups: { 'group-id': true } })).toBe(true);
+    expect(isGroupedChallenge({ groups: [] })).toBe(false);
+    expect(isGroupedChallenge({ groups: {} })).toBe(false);
+  });
+
+  test('requires login only for anonymous grouped challenge payloads', () => {
+    expect(shouldLoginForGroupedChallenge({}, { groups: ['group-id'] })).toBe(true);
+    expect(shouldLoginForGroupedChallenge({ tokenV3: 'token' }, { groups: ['group-id'] }))
+      .toBe(false);
+    expect(shouldLoginForGroupedChallenge({}, { groups: [] })).toBe(false);
+  });
+
+  test('detects grouped challenge access errors for anonymous detail requests', () => {
+    expect(isGroupedChallengeAccessError({ payload: new Error('Forbidden') })).toBe(true);
+    expect(isGroupedChallengeAccessError(new Error('You do not have access to this group')))
+      .toBe(true);
+    expect(isGroupedChallengeAccessError(new Error('Not Found'))).toBe(false);
+
+    expect(shouldLoginForGroupedChallengeError({}, { payload: new Error('Forbidden') }))
+      .toBe(true);
+    expect(shouldLoginForGroupedChallengeError({ tokenV3: 'token' }, new Error('Forbidden')))
+      .toBe(false);
+  });
+
+  test('builds a login URL that preserves the original challenge URL', () => {
+    const retUrl = 'https://www.topcoder.com/challenges/abc?tab=details#timeline';
+    const loginUrl = buildChallengeLoginUrl(retUrl);
+    const parsedUrl = new URL(loginUrl);
+
+    expect(`${parsedUrl.origin}${parsedUrl.pathname}`)
+      .toBe('https://accounts-auth0.topcoder-dev.com/member');
+    expect(parsedUrl.searchParams.get('retUrl')).toBe(retUrl);
+    expect(parsedUrl.searchParams.get('utm_source')).toBe('community-app-main');
   });
 });

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -139,6 +139,87 @@ export function getDisplayWinners(challenge = {}) {
   });
 }
 
+/**
+ * Checks whether a challenge has associated groups.
+ * @param {Object} challenge Challenge details loaded by the challenge service.
+ * @return {Boolean} True when the challenge has one or more group IDs.
+ * @throws {Error} This function does not throw.
+ */
+export function isGroupedChallenge(challenge = {}) {
+  return !_.isEmpty(_.get(challenge, 'groups'));
+}
+
+/**
+ * Checks whether an anonymous user should be forced through login before
+ * viewing a grouped challenge.
+ * @param {Object} auth Authentication state from Redux.
+ * @param {Object} challenge Challenge details loaded by the challenge service.
+ * @return {Boolean} True when the user is anonymous and the challenge is grouped.
+ * @throws {Error} This function does not throw.
+ */
+export function shouldLoginForGroupedChallenge(auth = {}, challenge = {}) {
+  return !_.get(auth, 'tokenV3') && isGroupedChallenge(challenge);
+}
+
+/**
+ * Checks whether a challenge details error represents anonymous access to a
+ * grouped/private challenge.
+ * @param {Object|Error} error Error or Redux action returned by the details load.
+ * @return {Boolean} True when the error indicates grouped challenge access denial.
+ * @throws {Error} This function does not throw.
+ */
+export function isGroupedChallengeAccessError(error = {}) {
+  const message = _.toString(
+    _.get(error, 'payload.message')
+    || _.get(error, 'message')
+    || _.get(error, 'payload')
+    || error,
+  );
+
+  return /Forbidden|access to this group/i.test(message);
+}
+
+/**
+ * Checks whether an anonymous failed challenge details request should force
+ * login before showing the existing not-found/access-denied state.
+ * @param {Object} auth Authentication state from Redux.
+ * @param {Object|Error} error Error or Redux action returned by the details load.
+ * @return {Boolean} True when the anonymous request failed on grouped access.
+ * @throws {Error} This function does not throw.
+ */
+export function shouldLoginForGroupedChallengeError(auth = {}, error = {}) {
+  return !_.get(auth, 'tokenV3') && isGroupedChallengeAccessError(error);
+}
+
+/**
+ * Builds a Topcoder login URL that returns users to the challenge details URL.
+ * @param {String} retUrl Original challenge details URL to return to after login.
+ * @param {String} utmSource UTM source to add to the login URL.
+ * @return {String} Login URL with encoded return URL and UTM source.
+ * @throws {Error} This function does not throw.
+ */
+export function buildChallengeLoginUrl(retUrl, utmSource = 'community-app-main') {
+  return appendUtmParamsToUrl(
+    `${config.URL.AUTH}/member?retUrl=${encodeURIComponent(retUrl)}`,
+    { utm_source: utmSource },
+  );
+}
+
+/**
+ * Redirects the browser to login and preserves the current challenge details URL.
+ * @param {String} utmSource UTM source to add to the login URL.
+ * @return {Boolean} True when a browser redirect was initiated.
+ * @throws {Error} This function does not throw.
+ */
+export function redirectToChallengeLogin(utmSource = 'community-app-main') {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  window.location.href = buildChallengeLoginUrl(window.location.href, utmSource);
+  return true;
+}
+
 function hasRenderableStatisticsData(statisticsData) {
   return Array.isArray(statisticsData)
     && statisticsData.some(entry => (
@@ -1619,7 +1700,19 @@ const mapDispatchToProps = (dispatch) => {
       dispatch(a.getDetailsInit(challengeId));
       dispatch(a.getDetailsDone(challengeId, tokens.tokenV3, tokens.tokenV2))
         .then((res) => {
+          if (res.error) {
+            if (shouldLoginForGroupedChallengeError(tokens, res)) {
+              redirectToChallengeLogin();
+            }
+            return res;
+          }
+
           const ch = res.payload;
+          if (shouldLoginForGroupedChallenge(tokens, ch)) {
+            redirectToChallengeLogin();
+            return res;
+          }
+
           const chTrack = (ch && ch.track && ch.track.name) ? ch.track.name : ch.track;
           if (chTrack === COMPETITION_TRACKS.DES) {
             const p = ch.phases || []
@@ -1634,6 +1727,13 @@ const mapDispatchToProps = (dispatch) => {
             dispatch(a.loadResultsDone(ch.id));
           } else dispatch(a.dropResults());
           return res;
+        })
+        .catch((err) => {
+          if (shouldLoginForGroupedChallengeError(tokens, err)) {
+            redirectToChallengeLogin();
+            return err;
+          }
+          throw err;
         });
     },
     registerForChallenge: (auth, challengeId) => {


### PR DESCRIPTION
What was broken
Anonymous users opening a group-protected challenge details URL could land on the existing not-found/access-denied state instead of being sent through login first.

Root cause (if identifiable)
The challenge details load treats anonymous group-access failures as a generic failed challenge load, and the UI did not redirect anonymous users when a challenge payload or access error showed group protection.

What was changed
Added challenge-detail helpers to detect grouped challenge payloads and anonymous group-access failures, then redirect anonymous users to Topcoder login while preserving the original challenge URL. Authenticated users still follow the existing group membership access check.

Any added/updated tests
Added challenge-detail tests for grouped challenge detection, anonymous access-error detection, and login URL return-path preservation.

Validation run
npm run jest -- __tests__/shared/containers/challenge-detail/index.jsx
npm lint (not supported by npm 6; followed with npm run lint)
npm run lint
npm test
npm run build
