### PR TITLE
PM-5495: Remove Wipro payment section from challenge details

### DIFF
--- a/__tests__/shared/components/challenge-detail/Specification/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Specification/index.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Renderer from 'react-test-renderer/shallow';
+
+import { SPECS_TAB_STATES } from 'actions/page/challenge-details';
+import ChallengeDetailsView from 'components/challenge-detail/Specification';
+
+describe('Challenge detail specification Wipro payments', () => {
+  test('does not render the payment terms section for Wipro group challenges', () => {
+    const renderer = new Renderer();
+    renderer.render((
+      <ChallengeDetailsView
+        auth={{}}
+        challenge={{
+          description: 'Challenge description',
+          descriptionFormat: 'HTML',
+          events: [],
+          groups: ['wipro-group-id'],
+          legacy: { forumId: 0 },
+          metadata: [],
+          phases: [],
+          track: 'Development',
+          userDetails: { roles: [] },
+        }}
+        challengesUrl="/challenges"
+        communitiesList={[{
+          communityId: 'wipro',
+          groupIds: ['wipro-group-id'],
+        }]}
+        savingChallenge={false}
+        setSpecsTabState={jest.fn()}
+        specsTabState={SPECS_TAB_STATES.VIEW}
+        terms={[]}
+        updateChallenge={jest.fn()}
+      />
+    ));
+
+    const renderedText = JSON.stringify(renderer.getRenderOutput());
+
+    expect(renderedText).toContain('Challenge Overview');
+    expect(renderedText).not.toContain('Payments');
+    expect(renderedText).not.toContain('For employees of Wipro Technologies');
+  });
+});

--- a/src/shared/components/challenge-detail/Specification/index.jsx
+++ b/src/shared/components/challenge-detail/Specification/index.jsx
@@ -343,25 +343,6 @@ export default function ChallengeDetailsView(props) {
                   </div>
                 )
             }
-            {isWipro && (
-              <article>
-                <h2>
-                  Payments
-                </h2>
-                <div>
-                  <p>
-                    For employees of Wipro Technologies, following are the payment terms.
-                    Winner(s) will be awarded the reward money/Winner Circle Points (WCPs) on
-                    successful completion and acceptance of the submission by the stakeholder.
-                    Accumulated reward money for the month will be paid through Wipro payroll as part of subsequent
-                    month’s salary (eg. Aug month challenge winners payment will be credited as part of Sept month salary).
-                    WCPs will be credited to winner’s WCP wallet in 3-4 weeks post challenge closure.
-                    For payment of reward money/WCPs, respective country currency conversion will be
-                    considered as per Wipro standard currency conversion guidelines.
-                  </p>
-                </div>
-              </article>
-            )}
           </div>
         </div>
         { !isTopCrowdChallenge ? (


### PR DESCRIPTION
What was broken
Wipro and Topgear group challenge detail pages rendered an extra Payments section with Wipro payroll and WCP payment terms.

Root cause
The challenge detail specification component appended a hard-coded Payments article whenever the challenge belonged to the Wipro community group.

What was changed
Removed the Wipro-only Payments article from the challenge detail specification while keeping the Wipro community detection for existing sidebar behavior.

Any added/updated tests
Added a challenge detail specification regression test that renders a Wipro group challenge and verifies the payment section copy is absent.

Validation
- npm run jest -- __tests__/shared/components/challenge-detail/Specification/index.jsx
- npm run lint
- npm test
- npm run build
