### PR TITLE
PM-5481: Fix MM submissions leaderboard visibility

### DIFF
--- a/__tests__/shared/containers/challenge-detail/index.jsx
+++ b/__tests__/shared/containers/challenge-detail/index.jsx
@@ -1,4 +1,8 @@
-import { getDisplayWinners, isWiproRegistrationBlocked } from 'containers/challenge-detail';
+import {
+  getDisplayWinners,
+  isWiproRegistrationBlocked,
+  mapStateToProps,
+} from 'containers/challenge-detail';
 
 describe('Challenge detail Wipro registration guard', () => {
   test('blocks Wipro members when challenge disallows Wipro participation', () => {
@@ -64,6 +68,138 @@ describe('Challenge detail winners filter', () => {
 
     expect(winners).toEqual([
       { handle: 'taskWinner', type: 'provisional' },
+    ]);
+  });
+});
+
+describe('Challenge detail MM submissions state mapping', () => {
+  function createState() {
+    return {
+      auth: {
+        user: {},
+      },
+      challenge: {
+        details: {
+          id: 'challenge-id',
+          registrants: [
+            {
+              memberHandle: 'alpha',
+              memberId: '101',
+              rating: 1200,
+            },
+            {
+              memberHandle: 'beta',
+              memberId: '102',
+              rating: 1500,
+            },
+          ],
+          submissions: [
+            {
+              createdAt: '2026-06-29T01:00:00.000Z',
+              id: 'raw-alpha',
+              memberId: '101',
+              registrant: {
+                memberHandle: 'alpha',
+                memberId: '101',
+              },
+            },
+          ],
+        },
+        mmSubmissions: {
+          challengeId: 'challenge-id',
+          data: [
+            {
+              finalRank: null,
+              member: 'alpha',
+              memberId: '101',
+              provisionalRank: 1,
+              submissions: [
+                {
+                  finalScore: null,
+                  provisionalScore: 75,
+                  status: 'completed',
+                  submissionId: 'raw-alpha',
+                  submissionTime: '2026-06-29T01:00:00.000Z',
+                },
+              ],
+            },
+            {
+              finalRank: null,
+              member: 'beta',
+              memberId: '102',
+              provisionalRank: 2,
+              submissions: [
+                {
+                  finalScore: null,
+                  provisionalScore: 70,
+                  status: 'completed',
+                  submissionId: 'full-beta',
+                  submissionTime: '2026-06-28T01:00:00.000Z',
+                },
+              ],
+            },
+          ],
+        },
+        reviewSummations: {
+          challengeId: 'challenge-id',
+          data: [
+            {
+              aggregateScore: 75,
+              id: 'summation-alpha',
+              isProvisional: true,
+              reviewedDate: '2026-06-29T01:10:00.000Z',
+              submissionId: 'raw-alpha',
+              submitterHandle: 'alpha',
+              submitterId: '101',
+            },
+          ],
+        },
+        statisticsData: [],
+        checkpoints: {},
+      },
+      challengeListing: {
+        challengeTypes: [],
+        challengeTypesMap: {},
+        openForRegistrationChallenges: {},
+      },
+      lookup: {
+        allCountries: [],
+        reviewTypes: [],
+      },
+      page: {
+        challengeDetails: {
+          checkpoints: {},
+          feedbackOpen: {},
+        },
+      },
+      tcCommunities: {
+        list: {
+          data: [],
+          loadingUuid: '',
+          timestamp: 0,
+        },
+      },
+      terms: {
+        loadingTermsForEntity: null,
+        terms: [],
+      },
+      topcoderHeader: {},
+    };
+  }
+
+  test('keeps fully fetched MM submitters when review summations are present', () => {
+    const props = mapStateToProps(createState(), {
+      challengesUrl: '/challenges',
+      match: {
+        params: {
+          challengeId: 'challenge-id',
+        },
+      },
+    });
+
+    expect(props.mmSubmissions.map(submission => submission.member)).toEqual([
+      'alpha',
+      'beta',
     ]);
   });
 });

--- a/__tests__/shared/utils/challenge-detail/mm-final-results.test.js
+++ b/__tests__/shared/utils/challenge-detail/mm-final-results.test.js
@@ -41,6 +41,29 @@ describe('mm-final-results utilities', () => {
     ])).toBe(false);
   });
 
+  it('keeps final Marathon Match results hidden while submissions are still open', () => {
+    const submissionPhaseChallenge = {
+      phases: [
+        {
+          isOpen: true,
+          name: 'Submission',
+          scheduledStartDate: '2030-01-01T00:00:00.000Z',
+        },
+      ],
+    };
+
+    expect(shouldShowFinalMmResults(submissionPhaseChallenge, [
+      {
+        finalRank: 1,
+        submissions: [
+          {
+            finalScore: 100,
+          },
+        ],
+      },
+    ])).toBe(false);
+  });
+
   it('shows final Marathon Match results as soon as a final score is available', () => {
     const mmSubmissions = [
       {

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
@@ -70,7 +70,7 @@ export default function SubmissionRow({
   };
 
   const getFinalReviewResult = () => {
-    if (_.isNil(finalScore)) {
+    if (!showFinalResults || _.isNil(finalScore)) {
       return 'N/A';
     }
     if (finalScore < 0) {

--- a/src/shared/components/challenge-detail/Submissions/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/index.jsx
@@ -742,8 +742,10 @@ class SubmissionsComponent extends React.Component {
           break;
         }
         case 'Final Score': {
-          valueA = toScoreValue(getFinalScore(primaryA));
-          valueB = toScoreValue(getFinalScore(primaryB));
+          if (showFinalMmResults) {
+            valueA = toScoreValue(getFinalScore(primaryA));
+            valueB = toScoreValue(getFinalScore(primaryB));
+          }
           break;
         }
         case 'Provisional Score': {

--- a/src/shared/containers/challenge-detail/index.jsx
+++ b/src/shared/containers/challenge-detail/index.jsx
@@ -1158,7 +1158,7 @@ function getLatestReviewSummationScore(summations = [], targetType = null) {
   return latest ? latest.score : null;
 }
 
-function mapStateToProps(state, props) {
+export function mapStateToProps(state, props) {
   const challengeId = String(props.match.params.challengeId);
   const cl = state.challengeListing;
   const { lookup: { allCountries, reviewTypes } } = state;
@@ -1171,7 +1171,7 @@ function mapStateToProps(state, props) {
     ? challenge.submissions
     : (_.get(challenge, 'submissions.data') || []);
   let mmSubmissions = extractArrayFromStateSlice(state.challenge.mmSubmissions, challengeId);
-  if (reviewSummations.length) {
+  if (!mmSubmissions.length && reviewSummations.length) {
     mmSubmissions = buildMmSubmissionData(reviewSummations, rawChallengeSubmissions);
   } else if (!mmSubmissions.length && rawChallengeSubmissions.length) {
     mmSubmissions = buildMmSubmissionData([], rawChallengeSubmissions);

--- a/src/shared/utils/challenge-detail/mm-final-results.js
+++ b/src/shared/utils/challenge-detail/mm-final-results.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import moment from 'moment';
+import { hasOpenSubmissionPhase } from 'utils/challengePhases';
 
 /**
  * Normalizes a displayed score or rank value into a finite number.
@@ -31,7 +32,7 @@ export function isReviewPhaseComplete(challenge = {}) {
 
 /**
  * Returns whether Marathon Match final scores or ranks already exist in the
- * loaded submission payload, even if the review phase is still active.
+ * loaded submission payload after submissions are closed.
  *
  * @param {Array} mmSubmissions grouped Marathon Match submissions.
  * @returns {boolean} true when at least one final result is available.
@@ -59,6 +60,10 @@ export function hasVisibleMmFinalResults(mmSubmissions = []) {
  * @returns {boolean} true when final results are ready for display.
  */
 export function shouldShowFinalMmResults(challenge = {}, mmSubmissions = []) {
+  if (hasOpenSubmissionPhase(challenge.phases)) {
+    return false;
+  }
+
   return isReviewPhaseComplete(challenge)
     || hasVisibleMmFinalResults(mmSubmissions);
 }


### PR DESCRIPTION
What was broken
- The MM submissions tab could collapse back to the capped submissions embedded in challenge details, so authenticated unregistered users saw only submitters from the recent submissions page.
- Final MM ranks and scores could render during an open submission phase when raw submission payloads included finalScore values.

Root cause (if identifiable)
- mapStateToProps rebuilt mmSubmissions from challenge.submissions whenever review summations existed, ignoring the fully paginated MM submissions already fetched into state.
- Final result visibility treated any loaded final score or rank as displayable without checking whether submissions were still open.

What was changed
- Prefer the fully fetched mmSubmissions state before falling back to challenge details data.
- Hide MM final ranks and scores while any submission phase is open, and prevent hidden final scores from affecting sort order.

Any added/updated tests
- Added regression coverage for preserving fully fetched MM submitters when review summations exist.
- Added final result visibility coverage for open submission phases.
