### PR TITLE
PM-5505: Keep Topgear payment validation passing

### DIFF
--- a/__tests__/shared/containers/challenge-detail/index.jsx
+++ b/__tests__/shared/containers/challenge-detail/index.jsx
@@ -1,5 +1,4 @@
 import {
-  mapStateToProps,
   buildChallengeLoginUrl,
   getDisplayWinners,
   isGroupedChallenge,


### PR DESCRIPTION
What was broken
Topgear challenge details previously displayed the Wipro payment terms section. The production removal and regression coverage are already present on the current develop base, but the package lint/test command was blocked by a stale unused import in the challenge-detail test suite.

Root cause (if identifiable)
The payment text came from a hardcoded Wipro challenge-details section. After that section was removed, the nearby challenge-detail container test still imported mapStateToProps even though the test no longer used it.

What was changed
Removed the unused mapStateToProps import from the challenge-detail container test so the existing PM-5505/Topgear payment regression coverage and full validation commands run cleanly.

Any added/updated tests
No new tests were needed because develop already includes a focused challenge-detail specification regression test asserting Wipro/Topgear payment terms are not rendered.

Validation
- npm run jest -- __tests__/shared/components/challenge-detail/Specification/index.jsx
- npm run lint
- npm test
- npm run build
