### PR TITLE
PM-5644: Fix final score sorting

### DIFF
--- a/__tests__/shared/components/challenge-detail/Submissions/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Submissions/index.jsx
@@ -1,4 +1,4 @@
-import {
+import Submissions, {
   enrichChallengeSubmissions,
   groupSubmissionsByMember,
 } from 'components/challenge-detail/Submissions';
@@ -88,5 +88,65 @@ describe('challenge detail Submissions helpers', () => {
       finalScore: 82,
       initialScore: 75,
     }));
+  });
+
+  it('sorts grouped submissions by final score', () => {
+    const component = new Submissions.WrappedComponent({
+      challenge: {
+        phases: [
+          {
+            isOpen: false,
+            name: 'Review',
+            scheduledStartDate: '2000-01-01T00:00:00.000Z',
+          },
+        ],
+        status: 'COMPLETED',
+        tags: [],
+        track: 'Development',
+        type: 'Challenge',
+      },
+      mmSubmissions: [],
+      submissionsSort: {
+        field: 'Final Score',
+        sort: 'desc',
+      },
+    });
+    const submissions = [
+      {
+        member: 'middle-score',
+        submissions: [{ finalScore: 68 }],
+      },
+      {
+        member: 'low-score',
+        submissions: [{ finalScore: 43.05 }],
+      },
+      {
+        member: 'high-score',
+        submissions: [{ finalScore: 94.8 }],
+      },
+    ];
+
+    component.sortSubmissions(submissions);
+
+    expect(submissions.map(submission => submission.member)).toEqual([
+      'high-score',
+      'middle-score',
+      'low-score',
+    ]);
+
+    component.props = {
+      ...component.props,
+      submissionsSort: {
+        field: 'Final Score',
+        sort: 'asc',
+      },
+    };
+    component.sortSubmissions(submissions);
+
+    expect(submissions.map(submission => submission.member)).toEqual([
+      'low-score',
+      'middle-score',
+      'high-score',
+    ]);
   });
 });

--- a/src/shared/components/challenge-detail/Submissions/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/index.jsx
@@ -867,8 +867,8 @@ class SubmissionsComponent extends React.Component {
         }
         case 'Final Score': {
           if (showFinalMmResults) {
-            valueA = toScoreValue(getFinalScore(primaryA));
-            valueB = toScoreValue(getFinalScore(primaryB));
+            valueA = toScoreValue(getFinalScore(a));
+            valueB = toScoreValue(getFinalScore(b));
           }
           break;
         }


### PR DESCRIPTION
## What was broken

Sorting the challenge details Submissions tab by Final Score did not change the member row order.

## Root cause (if identifiable)

Non-Marathon submissions are grouped by member, but the Final Score comparator passed each flat latest submission to a helper that expects the group containing a `submissions` array. The helper therefore returned zero for every row, leaving the original order unchanged.

## What was changed

Pass the grouped member rows to the existing final-score helper so it compares each member's latest final score.

## Any added/updated tests

Added regression coverage for ascending and descending Final Score sorting on grouped submissions.

Validation completed successfully:

- `npm test` — 150 suites passed, 313 tests passed, 141 snapshots passed
- `npm run lint`
- `npm run build`
