### PR TITLE
PM-5778: Show N/A for in-progress scores

### DIFF
--- a/__tests__/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
+++ b/__tests__/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import Renderer from 'react-test-renderer/shallow';
+import SubmissionRow from 'components/challenge-detail/Submissions/SubmissionRow';
+
+/**
+ * Locates a rendered table column by the text in its direct header child.
+ * Tests use this to inspect one score column without relying on generated CSS class names.
+ *
+ * @param {React.Node} node Rendered React node to search.
+ * @param {String} header Header text identifying the column.
+ * @returns {React.Element|null} Matching column element, or null when not found.
+ * @throws This function does not throw.
+ */
+function findColumnByHeader(node, header) {
+  if (!React.isValidElement(node)) {
+    return null;
+  }
+
+  const children = React.Children.toArray(node.props.children);
+  const hasHeader = children.some(child => (
+    React.isValidElement(child)
+    && React.Children.toArray(child.props.children).includes(header)
+  ));
+
+  if (hasHeader) {
+    return node;
+  }
+
+  return children.reduce(
+    (column, child) => column || findColumnByHeader(child, header),
+    null,
+  );
+}
+
+/**
+ * Collects primitive text and number children from a rendered React node.
+ * Tests use the returned values to assert a column's visible label and score.
+ *
+ * @param {React.Node} node Rendered React node to traverse.
+ * @returns {Array<String|Number>} Visible primitive child values in render order.
+ * @throws This function does not throw.
+ */
+function collectText(node) {
+  if (typeof node === 'string' || typeof node === 'number') {
+    return [node];
+  }
+  if (!React.isValidElement(node)) {
+    return [];
+  }
+
+  return React.Children.toArray(node.props.children)
+    .reduce((text, child) => text.concat(collectText(child)), []);
+}
+
+/**
+ * Shallow-renders an MM row and returns its provisional score column text.
+ * Tests use this to compare score display behavior across scorer process states.
+ *
+ * @param {String} testProcess Review API test process metadata.
+ * @param {String} testStatus Review API test status metadata.
+ * @returns {Array<String|Number>} Provisional score column label and displayed value.
+ * @throws {Error} Propagates errors raised while shallow-rendering SubmissionRow.
+ */
+function renderProvisionalScore(testProcess, testStatus) {
+  const renderer = new Renderer();
+  renderer.render(
+    <SubmissionRow
+      auth={{}}
+      challengeStatus="ACTIVE"
+      isMM
+      isRDM={false}
+      member="test-member"
+      numWinners={0}
+      onShowPopup={jest.fn()}
+      openHistory={false}
+      submissions={[
+        {
+          finalScore: null,
+          id: 'submission-id',
+          provisionalScore: 0,
+          reviewSummations: [
+            {
+              metadata: {
+                testProcess,
+                testStatus,
+              },
+            },
+          ],
+          status: 'completed',
+          submissionId: 'submission-id',
+          submissionTime: '2026-07-30T00:00:00.000Z',
+        },
+      ]}
+      viewAsTable
+    />,
+  );
+
+  const column = findColumnByHeader(renderer.getRenderOutput(), 'PROVISIONAL SCORE');
+  return collectText(column);
+}
+
+describe('Marathon Match provisional score', () => {
+  it('shows N/A while provisional tests are still running', () => {
+    expect(renderProvisionalScore('provisional', 'IN PROGRESS'))
+      .toEqual(['PROVISIONAL SCORE', 'N/A']);
+  });
+
+  it('keeps a completed zero provisional score visible', () => {
+    expect(renderProvisionalScore('provisional', 'SUCCESS'))
+      .toEqual(['PROVISIONAL SCORE', 0]);
+  });
+
+  it('keeps the provisional score visible while system tests are running', () => {
+    expect(renderProvisionalScore('system', 'IN PROGRESS'))
+      .toEqual(['PROVISIONAL SCORE', 0]);
+  });
+});

--- a/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -163,7 +163,7 @@ function normalizeTestProgress(value) {
 /**
  * Returns display-ready test process, status, and percent progress for a submission.
  *
- * @param {Object} submission submission attempt shown in My Submissions.
+ * @param {Object} submission submission attempt shown in a Marathon Match submissions table.
  * @returns {Object} display process, status, and progress percentage.
  * Marathon Match competitors receive only sanitized progress metadata from Review API.
  */

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
@@ -12,6 +12,10 @@ import IconClose from 'assets/images/icon-close-green.svg';
 import moment from 'moment';
 
 import LoadingIndicator from 'components/LoadingIndicator';
+import {
+  getSubmissionTestProgress,
+  isActiveTestStatus,
+} from 'components/challenge-detail/MySubmissions/SubmissionsList';
 import FailedSubmissionTooltip from '../FailedSubmissionTooltip';
 import InReview from '../../icons/in-review.svg';
 import Queued from '../../icons/queued.svg';
@@ -50,6 +54,9 @@ export default function SubmissionRow({
   const provisionalScore = parseScore(_.get(latestSubmission, 'provisionalScore'));
   const finalScore = parseScore(submissionFinalScore);
   const initialScoreValue = parseScore(initialScore);
+  const testProgress = getSubmissionTestProgress(latestSubmission);
+  const hideProvisionalScore = testProgress.process !== 'system'
+    && isActiveTestStatus(testProgress.status);
 
   const getInitialReviewResult = () => {
     if (status === 'failed') {
@@ -60,6 +67,9 @@ export default function SubmissionRow({
     }
     if (status === 'queued') {
       return <Queued />;
+    }
+    if (hideProvisionalScore) {
+      return 'N/A';
     }
     if (_.isNil(provisionalScore)) {
       return 'N/A';


### PR DESCRIPTION
## What was broken

Marathon Match public submission rows displayed a provisional placeholder score of 0 while provisional tests were still running, which made a pending result look final.

## Root cause

The row treated every finite provisional score as display-ready data and did not consult the Review API test status already attached to the submission.

## What was changed

The public submission row now reuses the existing Marathon Match progress helpers and displays N/A while provisional scoring is active. Completed zero scores and completed provisional scores during system testing remain visible. The shared helper documentation was updated for its broader use.

## Any added/updated tests

Added focused submission-row tests covering in-progress provisional scoring, a successful zero score, and an in-progress system run.

Validation passed with the focused tests, the full test suite (151 suites and 315 tests), lint, and the production build.
