### PR TITLE
PM-5759: Fix pending submission malware status

### DIFF
--- a/__tests__/shared/utils/tc.js
+++ b/__tests__/shared/utils/tc.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { processSRM } from 'utils/tc';
+import { processSRM, safeForDownload } from 'utils/tc';
 
 describe('utils/tc', () => {
   test('processSRM', () => {
@@ -17,5 +17,41 @@ describe('utils/tc', () => {
       rounds: [{}],
     }];
     _.forEach(srms, s => processSRM(s));
+  });
+});
+
+describe('safeForDownload', () => {
+  test('keeps a DMZ submission pending while virusScan is false', () => {
+    expect(safeForDownload({
+      url: 'https://s3.amazonaws.com/topcoder-dev-submissions-dmz/submission.zip',
+      virusScan: false,
+    })).toBe('AV Scan in progress');
+  });
+
+  test('identifies a quarantined submission as malware', () => {
+    expect(safeForDownload({
+      url: 'https://s3.amazonaws.com/topcoder-dev-submissions-quarantine/submission.zip',
+      virusScan: false,
+    })).toBe('Malware found in submission');
+  });
+
+  test('preserves the legacy failed scan fallback outside the DMZ', () => {
+    expect(safeForDownload({
+      url: 'https://downloads.example.com/submission.zip',
+      virusScan: false,
+    })).toBe('Malware found in submission');
+  });
+
+  test('keeps an unknown scan result pending', () => {
+    expect(safeForDownload({
+      url: 'https://downloads.example.com/submission.zip',
+    })).toBe('AV Scan in progress');
+  });
+
+  test('allows a clean submission to be downloaded', () => {
+    expect(safeForDownload({
+      url: 'https://downloads.example.com/submission.zip',
+      virusScan: true,
+    })).toBe(true);
   });
 });

--- a/src/shared/utils/tc.js
+++ b/src/shared/utils/tc.js
@@ -377,7 +377,9 @@ export function isValidEmail(email) {
 
 /**
  * Test if the file is safe for download. This function can accept the full submission object.
+ * Quarantine URLs identify malware, while DMZ URLs identify submissions whose scan is pending.
  *
+ * @param {Object} submission The submission containing its URL and virus scan result
  * @returns {String|Boolean} true if submission is safe for download,
  * otherwise string describing reason for not being safe for download
  */
@@ -385,11 +387,19 @@ export function safeForDownload(submission) {
   if (submission == null || !submission.url) return 'Download link unavailable';
 
   const { url } = submission;
-  if (url.toLowerCase().indexOf('submissions-quarantine/') !== -1 || submission.virusScan === false) {
+  if (url.toLowerCase().indexOf('submissions-quarantine/') !== -1) {
     return 'Malware found in submission';
   }
 
-  if (url.toLowerCase().indexOf('submissions-dmz/') !== -1 || !submission.virusScan) {
+  if (url.toLowerCase().indexOf('submissions-dmz/') !== -1) {
+    return 'AV Scan in progress';
+  }
+
+  if (submission.virusScan === false) {
+    return 'Malware found in submission';
+  }
+
+  if (!submission.virusScan) {
     return 'AV Scan in progress';
   }
 


### PR DESCRIPTION
## What was broken

Newly uploaded design submissions could show **Malware found in submission** while antivirus scanning was still pending. Most warnings disappeared after the clean scan completed, while delayed or failed scans could retain the false label.

## Root cause

The review API initializes every new file submission with `virusScan: false` and a DMZ URL. The community app checked the boolean first and treated it as confirmed malware before recognizing the DMZ URL as an in-progress scan.

## What was changed

The download-safety helper now gives known bucket locations precedence:

- Quarantine submissions remain classified as malware.
- DMZ submissions display **AV Scan in progress**, even while `virusScan` is `false`.
- Existing non-DMZ failed-scan and unknown-state fallbacks remain unchanged.

The helper documentation was updated to describe the bucket precedence.

## Any added/updated tests

Added five `safeForDownload` unit cases covering DMZ pending, quarantine malware, the legacy failed-scan fallback, an unknown scan result, and a clean scan.

Validation completed successfully:

- `npm run jest -- __tests__/shared/utils/tc.js` — 6 tests passed.
- `npm test` — 150 suites passed, 318 tests passed, 23 tests skipped.
- `npm run lint` — passed.
- `npm run build` — passed.
