### PR TITLE
PM-5751: Preserve MM test progress metadata

### DIFF
--- a/__tests__/shared/utils/mm-review-summations.test.js
+++ b/__tests__/shared/utils/mm-review-summations.test.js
@@ -210,6 +210,58 @@ describe('buildMmSubmissionData', () => {
     ]);
   });
 
+  it('preserves nested test progress metadata when top-level summations omit it', () => {
+    const reviewSummations = [
+      {
+        aggregateScore: 98.85,
+        id: 'summation-system',
+        isFinal: true,
+        reviewedDate: '2026-06-26T03:02:01.000Z',
+        submissionId: 'submission-latest',
+        submitterHandle: 'alpha',
+        submitterId: '1001',
+      },
+    ];
+    const rawSubmissions = [
+      {
+        createdAt: '2026-06-26T03:02:01.000Z',
+        id: 'submission-latest',
+        memberId: '1001',
+        registrant: {
+          memberHandle: 'alpha',
+          memberId: '1001',
+        },
+        reviewSummation: [
+          {
+            aggregateScore: 98.85,
+            id: 'summation-system',
+            isFinal: true,
+            metadata: {
+              testProcess: 'system',
+              testProgress: 1,
+              testStatus: 'SUCCESS',
+            },
+            submissionId: 'submission-latest',
+          },
+        ],
+      },
+    ];
+
+    const result = buildMmSubmissionData(reviewSummations, rawSubmissions);
+
+    expect(result[0].submissions[0].reviewSummations).toEqual([
+      expect.objectContaining({
+        id: 'summation-system',
+        metadata: {
+          testProcess: 'system',
+          testProgress: 1,
+          testStatus: 'SUCCESS',
+        },
+        submitterHandle: 'alpha',
+      }),
+    ]);
+  });
+
   it('uses v6 submitter fields and submittedDate for imported raw submissions', () => {
     const rawSubmissions = [
       {

--- a/src/shared/utils/mm-review-summations.js
+++ b/src/shared/utils/mm-review-summations.js
@@ -205,7 +205,7 @@ function getSubmissionIdentifier(submission, index, handle) {
 
 function dedupeReviewSummations(reviewSummations = []) {
   const deduped = [];
-  const seen = new Set();
+  const seen = new Map();
 
   reviewSummations.forEach((summation, index) => {
     if (!summation) {
@@ -216,10 +216,23 @@ function dedupeReviewSummations(reviewSummations = []) {
       || `${_.toString(_.get(summation, 'submissionId', '')).trim()}::${_.toString(_.get(summation, 'legacySubmissionId', '')).trim()}::${_.toString(_.get(summation, 'submitterId', '')).trim()}::${_.toString(_.get(summation, 'aggregateScore', '')).trim()}::${_.toString(_.get(summation, 'reviewedDate', '')).trim()}::${index}`;
 
     if (seen.has(dedupeKey)) {
+      const dedupedIndex = seen.get(dedupeKey);
+      const metadata = _.get(summation, 'metadata');
+      if (_.isObject(metadata)) {
+        const existingMetadata = _.get(deduped[dedupedIndex], 'metadata');
+        deduped[dedupedIndex] = {
+          ...deduped[dedupedIndex],
+          ...summation,
+          metadata: {
+            ...(_.isObject(existingMetadata) ? existingMetadata : {}),
+            ...metadata,
+          },
+        };
+      }
       return;
     }
 
-    seen.add(dedupeKey);
+    seen.set(dedupeKey, deduped.length);
     deduped.push(summation);
   });
 


### PR DESCRIPTION
## What was broken

The Community app's My Submissions table left Current Tests Process, Test Status, and Test Progress blank for Marathon Match submissions.

## Root cause

Community merged metadata-free rows from `/reviewSummations` before metadata-bearing nested rows from `/submissions`. Duplicate summation IDs used first-wins deduplication, discarding the safe test progress metadata.

## What was changed

Updated review summation deduplication to merge object metadata from later duplicate rows while retaining submitter enrichment from the original row.

## Any added/updated tests

Added a regression test that combines metadata-free top-level and metadata-bearing nested copies of the same summation and verifies a single merged row retains submitter data and all three test progress fields.
