### PR TITLE
PM-5488: Keep active registered challenges in My Challenges

### DIFF
--- a/__tests__/shared/actions/challenge-listing/index.js
+++ b/__tests__/shared/actions/challenge-listing/index.js
@@ -60,7 +60,7 @@ describe('live challenge listing filters', () => {
     }));
   });
 
-  test('only requests My Challenges with an open submission phase', async () => {
+  test('requests all active challenges registered to the member', async () => {
     const action = actions.getMyChallengesDone(
       'my-uuid',
       0,
@@ -74,11 +74,12 @@ describe('live challenge listing filters', () => {
     expect(mockGetChallenges).toHaveBeenCalledWith(expect.objectContaining({
       backendFilter,
       frontFilter: expect.objectContaining({
-        currentPhaseName: 'Submission',
         memberId: '123',
         status: 'ACTIVE',
       }),
     }));
+    expect(mockGetChallenges.mock.calls[0][0].frontFilter)
+      .not.toHaveProperty('currentPhaseName');
   });
 
   test('counts only live challenges with an open submission phase', async () => {

--- a/src/shared/actions/challenge-listing/index.js
+++ b/src/shared/actions/challenge-listing/index.js
@@ -303,7 +303,6 @@ function getMyChallengesDone(uuid, page, backendFilter, tokenV3, frontFilter = {
       ...frontFilter,
       ...extractSearchFilter(frontFilter),
       status: 'ACTIVE',
-      currentPhaseName: 'Submission',
       memberId: userId,
       perPage: PAGE_SIZE,
       page: page + 1,


### PR DESCRIPTION
## What was broken

PR #7243 prevented scheduled and later-phase challenges from appearing in the live list by requiring an open Submission phase for All, My Challenges, and the total count. QA found that registered members then lost their still-ACTIVE challenges from My Challenges as soon as submission closed and review began.

## Root cause

The public-list phase filter was also applied to the member-scoped My Challenges request. That request already uses memberId to identify the member's registered challenges, so currentPhaseName over-restricted the results.

## What was changed

Removed the Submission phase constraint only from My Challenges while retaining its ACTIVE status and memberId filters. Kept the Submission filters for All and the total count so scheduled and later-phase challenges remain excluded from the public live list.

## Any added/updated tests

Updated the action regression test to require ACTIVE status and memberId for My Challenges and explicitly verify that currentPhaseName is omitted. Existing action tests continue to verify the Submission filter for All and the total count.

Validation completed successfully:

- `npm run jest -- __tests__/shared/actions/challenge-listing/index.js` — 3 tests passed
- `npm run lint`
- `npm run build`
- `npm test` — 151 test suites, 322 tests, and 141 snapshots passed
