### PR TITLE
PM-5803: Show provisional score during system tests

### DIFF
--- a/__tests__/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/__tests__/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -1,8 +1,62 @@
-import {
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import SubmissionsListView, {
   getDisplayedScores,
   isActiveTestStatus,
   getSubmissionTestProgress,
 } from '../../../../../../src/shared/components/challenge-detail/MySubmissions/SubmissionsList';
+
+/**
+ * Renders a My Submissions row and returns its visible provisional score.
+ * Tests use this to compare score display behavior across scorer processes.
+ *
+ * @param {String} testProcess Review API test process metadata.
+ * @returns {String} provisional score displayed in the submission row.
+ * @throws {Error} Propagates errors raised while shallow-rendering SubmissionsListView.
+ */
+function renderProvisionalScore(testProcess) {
+  const wrapper = shallow(
+    <SubmissionsListView
+      auth={{ tokenV3: 'token' }}
+      challenge={{ id: 'challenge-id', metadata: [] }}
+      challengesUrl="/challenges"
+      hasRegistered
+      isLegacyMM={false}
+      mySubmissions={[
+        {
+          createdAt: '2026-08-04T01:05:51.000Z',
+          finalScore: 0,
+          initialScore: 75.82,
+          provisionalScore: 0,
+          reviewSummations: [
+            {
+              metadata: {
+                testProcess,
+                testProgress: 0.66,
+                testStatus: 'IN PROGRESS',
+              },
+            },
+          ],
+          status: 'completed',
+          submissionId: 'submission-id',
+        },
+      ]}
+      submissionEnded={false}
+      submissionsSort={{ field: '', sort: '' }}
+      unregistering={false}
+    />,
+  );
+  const scoreColumn = wrapper.find('div')
+    .filterWhere((node) => {
+      const firstChild = node.children().at(0);
+      return firstChild.type() === 'div'
+        && firstChild.text() === 'Provisional Score';
+    })
+    .first();
+
+  return scoreColumn.find('span').last().text();
+}
 
 describe('getDisplayedScores', () => {
   test('shows final scores when a system review already produced one before review completes', () => {
@@ -75,5 +129,15 @@ describe('isActiveTestStatus', () => {
     expect(isActiveTestStatus('IN PROGRESS')).toBe(true);
     expect(isActiveTestStatus('SUCCESS')).toBe(false);
     expect(isActiveTestStatus('FAILED')).toBe(false);
+  });
+});
+
+describe('Marathon Match provisional score display', () => {
+  it('keeps the completed provisional score visible while system tests are running', () => {
+    expect(renderProvisionalScore('system')).toBe('75.82');
+  });
+
+  it('keeps the provisional score hidden while provisional tests are running', () => {
+    expect(renderProvisionalScore('provisional')).toBe('-');
   });
 });

--- a/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
+++ b/src/shared/components/challenge-detail/MySubmissions/SubmissionsList/index.jsx
@@ -646,7 +646,8 @@ class SubmissionsListView extends React.Component {
             sortedSubmissions.map((mySubmission) => {
               let { finalScore, provisionalScore } = getDisplayedScores(mySubmission);
               const testProgress = getSubmissionTestProgress(mySubmission);
-              const hideProvisionalScore = isActiveTestStatus(testProgress.status);
+              const hideProvisionalScore = testProgress.process !== 'system'
+                && isActiveTestStatus(testProgress.status);
               if (_.isNumber(finalScore)) {
                 if (finalScore > 0) {
                   finalScore = finalScore.toFixed(2);


### PR DESCRIPTION
What was broken

The My Submissions tab replaced a completed Marathon Match provisional score with a dash while system tests were still running.

Root cause

The row hid the provisional score for every in-progress test status without distinguishing an in-progress provisional run from a later system run.

What was changed

The My Submissions row now keeps the completed provisional score visible when the current test process is system, matching the existing public submissions behavior.

Any added/updated tests

Added focused My Submissions row tests covering both an in-progress system run and an in-progress provisional run. The focused test, full test suite, lint, and production build pass.
