### PR TITLE
PM-5831: Fix My Submissions download redirect

### DIFF
--- a/__tests__/shared/services/submissions.js
+++ b/__tests__/shared/services/submissions.js
@@ -1,6 +1,9 @@
 /* eslint-env jest */
 import { config } from 'topcoder-react-utils';
-import { getChallengeSubmissions } from '../../../src/shared/services/submissions';
+import {
+  getChallengeSubmissions,
+  getSubmissionDownloadUrl,
+} from '../../../src/shared/services/submissions';
 
 const baseUrl = `${config.API.V6}/submissions`;
 
@@ -33,6 +36,36 @@ describe('submissions service', () => {
 
   beforeEach(() => {
     global.fetch = jest.fn();
+  });
+
+  it('returns a signed submission URL without following the storage redirect', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({
+        url: ' https://storage.example.test/signed-submission ',
+      }),
+    });
+
+    const result = await getSubmissionDownloadUrl('token-v3', 'submission/id');
+
+    expect(result).toBe('https://storage.example.test/signed-submission');
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(global.fetch).toHaveBeenCalledWith(
+      `${baseUrl}/submission%2Fid/download-url`,
+      expect.objectContaining({ method: 'GET' }),
+    );
+    expect(global.fetch.mock.calls[0][1].headers.get('Authorization'))
+      .toBe('Bearer token-v3');
+  });
+
+  it('rejects a submission download response without a signed URL', async () => {
+    global.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({}),
+    });
+
+    await expect(getSubmissionDownloadUrl('token-v3', 'submission-id'))
+      .rejects.toThrow('Submission download URL is missing');
   });
 
   it('loads every submissions page reported by metadata', async () => {

--- a/src/shared/containers/SubmissionManagement/index.jsx
+++ b/src/shared/containers/SubmissionManagement/index.jsx
@@ -15,15 +15,18 @@ import { safeForDownload } from 'utils/tc';
 import { connect } from 'react-redux';
 import { Modal, PrimaryButton } from 'topcoder-react-ui-kit';
 import { config } from 'topcoder-react-utils';
-import { actions, services } from 'topcoder-react-lib';
+import { actions } from 'topcoder-react-lib';
 import getReviewSummationsService from 'services/reviewSummations';
-import { getSubmissionArtifacts, downloadSubmissions } from 'services/submissions';
+import {
+  downloadSubmissions,
+  getSubmissionArtifacts,
+  getSubmissionDownloadUrl,
+} from 'services/submissions';
 
 import style from './styles.scss';
 import smpActions from '../../actions/page/submission_management';
 
 
-const { getService } = services.submissions;
 const SUMMATION_TYPE_PRIORITY = {
   example: 0,
   provisional: 1,
@@ -401,12 +404,10 @@ class SubmissionManagementPageContainer extends React.Component {
       onShowDetails,
       onDelete: onSubmissionDelete,
       onDownload: (challengeType, submissionId) => {
-        const submissionsService = getService(authTokens.tokenV3);
-        submissionsService.downloadSubmission(submissionId)
-          .then((blob) => {
-            const url = window.URL.createObjectURL(new Blob([blob]));
+        getSubmissionDownloadUrl(authTokens.tokenV3, submissionId)
+          .then((downloadUrl) => {
             const link = document.createElement('a');
-            link.href = url;
+            link.href = downloadUrl;
             link.setAttribute('download', `submission-${challengeType}-${submissionId}.zip`);
             document.body.appendChild(link);
             link.click();

--- a/src/shared/services/submissions.js
+++ b/src/shared/services/submissions.js
@@ -25,6 +25,37 @@ function getHeaders(tokenV3) {
   return headers;
 }
 
+/**
+ * Requests a short-lived URL for downloading a submission directly from storage.
+ *
+ * @param {String} tokenV3 Topcoder auth token v3 used to authorize the download.
+ * @param {String|Number} submissionId Submission identifier used by the Review API.
+ * @return {Promise<String>} Signed submission download URL.
+ * @throws {Error} Throws when the submission id is empty, the request fails, or no URL is returned.
+ */
+export async function getSubmissionDownloadUrl(tokenV3, submissionId) {
+  const normalizedSubmissionId = String(submissionId).trim();
+  if (!normalizedSubmissionId) {
+    throw new Error('Submission id is required');
+  }
+
+  const response = await fetch(`${v6ApiUrl}/submissions/${encodeURIComponent(normalizedSubmissionId)}/download-url`, {
+    method: 'GET',
+    headers: getHeaders(tokenV3),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get submission download URL: ${response.status} ${response.statusText}`);
+  }
+
+  const payload = await response.json();
+  if (!payload || typeof payload.url !== 'string' || !payload.url.trim()) {
+    throw new Error('Submission download URL is missing');
+  }
+
+  return payload.url.trim();
+}
+
 async function fetchChallengeSubmissionsPage({
   tokenV3,
   challengeId,


### PR DESCRIPTION
## What was broken

Downloading a submission from the My Submissions page failed after Review API began returning a signed storage redirect.

## Root cause

Community App fetched the redirecting download endpoint as a blob. Firefox followed that authenticated request to S3, which triggered a rejected CORS preflight instead of downloading the file.

## What was changed

- Request the browser-safe `/submissions/{submissionId}/download-url` endpoint with the member token.
- Validate the signed URL returned by Review API.
- Start the existing browser-managed download directly from the signed URL, avoiding the cross-origin blob request.
- Preserve the existing submission filename and leave artifact downloads unchanged.

## Any added/updated tests

- Added service tests for the authenticated, URL-encoded `download-url` request.
- Added coverage for signed URL trimming and missing URL rejection.
- Verified the focused tests, full test suite, lint, and production build all pass.
