### PR TITLE
Fix profile links to bypass redirects

### DIFF
--- a/__tests__/shared/components/Header/__snapshots__/index.jsx.snap
+++ b/__tests__/shared/components/Header/__snapshots__/index.jsx.snap
@@ -32,8 +32,8 @@ exports[`Default render 1`] = `
               "title": "Home",
             },
             Object {
-              "href": "/members/willFilledByUserName",
-              "id": "myprofile",
+              "href": "https://profiles.topcoder-dev.com/huanner",
+              "id": "profile",
               "logged": true,
               "title": "My Profile",
             },

--- a/__tests__/shared/components/Leaderboard/__snapshots__/LeaderboardTable.jsx.snap
+++ b/__tests__/shared/components/Leaderboard/__snapshots__/LeaderboardTable.jsx.snap
@@ -57,7 +57,7 @@ exports[`Matches shallow shapshot 1`] = `
         className="src-shared-components-Leaderboard-LeaderboardTable-themes-___styles__col-handle___1wDhG"
       >
         <a
-          href="https://www.topcoder-dev.com/members/undefined/"
+          href="https://profiles.topcoder-dev.com/undefined"
           rel="noreferrer"
           style={
             Object {
@@ -111,7 +111,7 @@ exports[`Matches shallow shapshot 1`] = `
         className="src-shared-components-Leaderboard-LeaderboardTable-themes-___styles__col-handle___1wDhG"
       >
         <a
-          href="https://www.topcoder-dev.com/members/undefined/"
+          href="https://profiles.topcoder-dev.com/undefined"
           rel="noreferrer"
           style={
             Object {
@@ -165,7 +165,7 @@ exports[`Matches shallow shapshot 1`] = `
         className="src-shared-components-Leaderboard-LeaderboardTable-themes-___styles__col-handle___1wDhG"
       >
         <a
-          href="https://www.topcoder-dev.com/members/undefined/"
+          href="https://profiles.topcoder-dev.com/undefined"
           rel="noreferrer"
           style={
             Object {
@@ -219,7 +219,7 @@ exports[`Matches shallow shapshot 1`] = `
         className="src-shared-components-Leaderboard-LeaderboardTable-themes-___styles__col-handle___1wDhG"
       >
         <a
-          href="https://www.topcoder-dev.com/members/undefined/"
+          href="https://profiles.topcoder-dev.com/undefined"
           rel="noreferrer"
           style={
             Object {

--- a/__tests__/shared/components/Leaderboard/__snapshots__/PodiumSpot.jsx.snap
+++ b/__tests__/shared/components/Leaderboard/__snapshots__/PodiumSpot.jsx.snap
@@ -21,7 +21,7 @@ exports[`Matches shallow shapshot 1`] = `
   <div>
     <a
       className="src-shared-components-Leaderboard-PodiumSpot-themes-___styles__profile-link___3s9pr"
-      href="undefined/members/undefined/"
+      href="https://profiles.topcoder-dev.com/undefined"
       target="_blank"
     />
   </div>
@@ -80,7 +80,7 @@ exports[`Matches shallow shapshot 2`] = `
   <div>
     <a
       className="src-shared-components-Leaderboard-PodiumSpot-themes-___styles__profile-link___3s9pr"
-      href="undefined/members/undefined/"
+      href="https://profiles.topcoder-dev.com/undefined"
       target="_blank"
     />
   </div>

--- a/__tests__/shared/components/__snapshots__/Content.jsx.snap
+++ b/__tests__/shared/components/__snapshots__/Content.jsx.snap
@@ -260,19 +260,17 @@ exports[`Matches shallow shapshot 1`] = `
        
       endpoint. Valid links on dev:
       <br />
-      <Link
-        replace={false}
-        to="/members/TonyJ"
+      <a
+        href="https://profiles.topcoder-dev.com/TonyJ"
       >
         Profile 1.
-      </Link>
+      </a>
       <br />
-      <Link
-        replace={false}
-        to="/members/mess"
+      <a
+        href="https://profiles.topcoder-dev.com/mess"
       >
         Profile 2.
-      </Link>
+      </a>
     </li>
     <li>
       Stand-alone terms of use page: ‌

--- a/__tests__/shared/components/challenge-detail/Winners/Winner/__snapshots__/index.jsx.snap
+++ b/__tests__/shared/components/challenge-detail/Winners/Winner/__snapshots__/index.jsx.snap
@@ -34,7 +34,7 @@ exports[`Matches shallow shapshot shapshot 1 1`] = `
         <div>
           <a
             className="src-shared-components-challenge-detail-Winners-Winner-___style__handle___2klay"
-            href="undefined/members/test"
+            href="https://profiles.topcoder-dev.com/test"
             target="_blank"
           >
             test

--- a/__tests__/shared/utils/url.test.js
+++ b/__tests__/shared/utils/url.test.js
@@ -1,0 +1,40 @@
+import {
+  getMemberProfileUrl,
+  getMenuWithDirectProfileLink,
+  updateLegacyProfileLinks,
+} from 'utils/url';
+
+describe('member profile URLs', () => {
+  it('uses the configured profile application URL', () => {
+    expect(getMemberProfileUrl('tourist'))
+      .toBe('https://profiles.topcoder-dev.com/tourist');
+  });
+
+  it('normalizes the profile entry in a navigation menu', () => {
+    const menu = [{
+      id: 'community',
+      secondaryMenu: [{ id: 'myprofile', href: '/members/placeholder' }],
+    }];
+
+    expect(getMenuWithDirectProfileLink(menu, 'tourist')[0].secondaryMenu[0])
+      .toEqual({
+        id: 'profile',
+        href: 'https://profiles.topcoder-dev.com/tourist',
+      });
+  });
+
+  it('updates only an exact legacy profile anchor rendered by navigation', () => {
+    const root = document.createElement('nav');
+    root.innerHTML = [
+      '<a href="/members/tourist">Profile</a>',
+      '<a href="/members/tourist/badges">Badges</a>',
+    ].join('');
+
+    updateLegacyProfileLinks(root, 'tourist');
+
+    expect(root.querySelector('a').getAttribute('href'))
+      .toBe('https://profiles.topcoder-dev.com/tourist');
+    expect(root.querySelectorAll('a')[1].getAttribute('href'))
+      .toBe('/members/tourist/badges');
+  });
+});

--- a/automated-smoke-test/config/automation-config-dev.json
+++ b/automated-smoke-test/config/automation-config-dev.json
@@ -34,7 +34,7 @@
   },
   "subMenuUrlsAfterLogin": {
     "dashboard": "https://community-app.topcoder-dev.com/my-dashboard",
-    "myProfile": "https://community-app.topcoder-dev.com/members/tester1234",
+    "myProfile": "https://profiles.topcoder-dev.com/tester1234",
     "payments": "https://community.topcoder-dev.com/PactsMemberServlet?module=PaymentHistory&full_list=false",
     "competitiveProgramming": "https://community-app.topcoder-dev.com/community/arena",
     "forums": "https://apps.topcoder-dev.com/forums/"

--- a/automated-smoke-test/config/automation-config-local.json
+++ b/automated-smoke-test/config/automation-config-local.json
@@ -34,7 +34,7 @@
   },
   "subMenuUrlsAfterLogin": {
     "dashboard": "http://localhost:3000/my-dashboard",
-    "myProfile": "http://localhost:3000/members/CustomerUser",
+    "myProfile": "https://profiles.topcoder-dev.com/CustomerUser",
     "payments": "https://community.topcoder.com/PactsMemberServlet?module=PaymentHistory&full_list=false",
     "forums": "https://apps.topcoder.com/forums/"
   },

--- a/automated-smoke-test/config/automation-config-prod.json
+++ b/automated-smoke-test/config/automation-config-prod.json
@@ -34,7 +34,7 @@
   },
   "subMenuUrlsAfterLogin": {
     "dashboard": "https://www.topcoder.com/my-dashboard",
-    "myProfile": "https://www.topcoder.com/members/CustomerUser",
+    "myProfile": "https://profiles.topcoder.com/CustomerUser",
     "payments": "https://community.topcoder.com/PactsMemberServlet?module=PaymentHistory&full_list=false",
     "forums": "https://apps.topcoder.com/forums/"
   },

--- a/automated-smoke-test/page-objects/pages/topcoder/header/header.po.ts
+++ b/automated-smoke-test/page-objects/pages/topcoder/header/header.po.ts
@@ -134,7 +134,7 @@ export class HeaderPage {
    * Gets the notification bell icon
    */
   private async getBellIcon() {
-    const xpath = `//a[contains(@href, '/members/${ConfigHelper.getUserName()}')]/parent::div/parent::div/div[position()=1]`;
+    const xpath = `//a[contains(@href, 'profiles.topcoder') and contains(@href, '/${ConfigHelper.getUserName()}')]/parent::div/parent::div/div[position()=1]`;
     const els = await ElementHelper.getAllElementsByXPath(xpath);
     return els[1];
   }

--- a/config/backup-default.js
+++ b/config/backup-default.js
@@ -310,9 +310,9 @@ module.exports = {
           logged: true,
         },
         {
-          id: 'myprofile',
+          id: 'profile',
           title: 'My Profile',
-          href: '/members/willFilledByUserName',
+          href: 'https://profiles.topcoder-dev.com/willFilledByUserName',
           logged: true,
         },
         {

--- a/config/default.js
+++ b/config/default.js
@@ -314,9 +314,9 @@ module.exports = {
           logged: true,
         },
         {
-          id: 'myprofile',
+          id: 'profile',
           title: 'My Profile',
-          href: '/members/willFilledByUserName',
+          href: 'https://profiles.topcoder-dev.com/willFilledByUserName',
           logged: true,
         },
         {

--- a/config/production.js
+++ b/config/production.js
@@ -100,9 +100,9 @@ module.exports = {
           logged: true,
         },
         {
-          id: 'myprofile',
+          id: 'profile',
           title: 'My Profile',
-          href: '/members/willFilledByUserName?ref=nav',
+          href: 'https://profiles.topcoder.com/willFilledByUserName',
           logged: true,
         },
         {

--- a/src/shared/actions/recruitCRM.js
+++ b/src/shared/actions/recruitCRM.js
@@ -2,6 +2,7 @@ import { redux } from 'topcoder-react-utils';
 import Service from 'services/recruitCRM';
 import _ from 'lodash';
 import { getCustomField } from 'utils/gigs';
+import { getMemberProfileUrl } from 'utils/url';
 
 /**
  * Jobs page fetch init
@@ -86,7 +87,7 @@ function normalizeRecruitPayload(job, payload) {
     custom_fields: [
       {
         field_id: 1,
-        value: payload.tcProfileLink || (payload.handle ? `https://topcoder.com/members/${payload.handle}` : ''),
+        value: payload.tcProfileLink || (payload.handle ? getMemberProfileUrl(payload.handle) : ''),
       },
       {
         field_id: 2,

--- a/src/shared/components/Content/index.jsx
+++ b/src/shared/components/Content/index.jsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { isomorphy } from 'topcoder-react-utils';
+import { getMemberProfileUrl } from 'utils/url';
 
 import './style.scss';
 
@@ -247,13 +248,13 @@ export default function Content() {
           endpoint.
           Valid links on dev:
           <br />
-          <Link to="/members/TonyJ">
+          <a href={getMemberProfileUrl('TonyJ')}>
             Profile 1.
-          </Link>
+          </a>
           <br />
-          <Link to="/members/mess">
+          <a href={getMemberProfileUrl('mess')}>
             Profile 2.
-          </Link>
+          </a>
         </li>
         <li>
           Stand-alone terms of use page:

--- a/src/shared/components/GSheet/index.jsx
+++ b/src/shared/components/GSheet/index.jsx
@@ -9,6 +9,7 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { Scrollbars } from 'react-custom-scrollbars';
 import cn from 'classnames';
+import { getMemberProfileUrl } from 'utils/url';
 import './style.scss';
 
 export default class GSheet extends Component {
@@ -88,7 +89,7 @@ export default class GSheet extends Component {
                   {
                     (config.pick || sheet.rows[0]._sheet.headerValues).map(c => (
                       <td key={`${record._rowNumber}-${c}`} title={record[c]} styleName="body-row">
-                        {c.toLowerCase() === 'handle' ? (<a styleName="handle-link" href={`${window.origin}/members/${record[c]}`} target="_blank" rel="noreferrer">{record[c]}</a>) : record[c]}
+                        {c.toLowerCase() === 'handle' ? (<a styleName="handle-link" href={getMemberProfileUrl(record[c])} target="_blank" rel="noreferrer">{record[c]}</a>) : record[c]}
                       </td>
                     ))
                   }

--- a/src/shared/components/Gigs/GigApply/index.jsx
+++ b/src/shared/components/Gigs/GigApply/index.jsx
@@ -12,6 +12,7 @@ import DropdownSkills from 'components/GUIKit/DropdownSkills';
 import RadioButton from 'components/GUIKit/RadioButton';
 import Checkbox from 'components/GUIKit/Checkbox';
 import { getCustomField } from 'utils/gigs';
+import { getMemberProfileUrl } from 'utils/url';
 import Modal from 'components/Contentful/Modal';
 import FilestackFilePicker from 'components/GUIKit/FilePicker';
 import Dropdown from 'components/GUIKit/Dropdown';
@@ -238,11 +239,11 @@ export default function GigApply(props) {
                           readonly
                         />
                         <TextInput
-                          placeholder="Topcoder Profile (topcoder.com/members/[username])"
+                          placeholder="Topcoder Profile (profiles.topcoder.com/[username])"
                           label="Topcoder Profile"
                           onChange={val => onFormInputChange('tcProfileLink', val)}
                           errorMsg={formErrors.tcProfileLink}
-                          value={formData.handle ? `https://topcoder.com/members/${formData.handle}` : null}
+                          value={formData.handle ? getMemberProfileUrl(formData.handle) : null}
                           readonly
                         />
                       </div>

--- a/src/shared/components/HallOfFamePage/Champions/Track/index.jsx
+++ b/src/shared/components/HallOfFamePage/Champions/Track/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import PT from 'prop-types';
 import _ from 'lodash';
 import { themr } from 'react-css-super-themr';
+import { getMemberProfileUrl } from 'utils/url';
 
 import defaultStyles from './styles.scss';
 
@@ -22,7 +23,7 @@ const Track = ({
       data.fields.members.map(member => (
         <div key={member.fields.handle} className={theme.champion}>
           <a
-            to={`${window.origin}/members/${member.fields.handle}`}
+            href={getMemberProfileUrl(member.fields.handle)}
             target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
           >
             {member.fields.handle}

--- a/src/shared/components/HallOfFamePage/Finalists/Track/index.jsx
+++ b/src/shared/components/HallOfFamePage/Finalists/Track/index.jsx
@@ -6,6 +6,7 @@ import React from 'react';
 import PT from 'prop-types';
 import _ from 'lodash';
 import { themr } from 'react-css-super-themr';
+import { getMemberProfileUrl } from 'utils/url';
 
 import defaultStyles from './styles.scss';
 
@@ -20,7 +21,7 @@ const Track = ({
       <img src={data.fields.champion.fields.image.fields.file.url} alt="Winner Portrait" />
       <div>
         <a
-          to={`${window.origin}/members/${data.fields.champion.fields.handle}`}
+          href={getMemberProfileUrl(data.fields.champion.fields.handle)}
           target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
         >
           {data.fields.champion.fields.handle}
@@ -34,7 +35,7 @@ const Track = ({
       data.fields.members.map(member => (
         <div key={member.fields.handle} className={theme.finalist}>
           <a
-            to={`${window.origin}/members/${member.fields.handle}`}
+            href={getMemberProfileUrl(member.fields.handle)}
             target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
           >
             {member.fields.handle}

--- a/src/shared/components/HallOfFamePage/TripWinners/Role/index.jsx
+++ b/src/shared/components/HallOfFamePage/TripWinners/Role/index.jsx
@@ -5,6 +5,7 @@ import React from 'react';
 import PT from 'prop-types';
 import _ from 'lodash';
 import { themr } from 'react-css-super-themr';
+import { getMemberProfileUrl } from 'utils/url';
 
 import defaultStyles from './styles.scss';
 
@@ -17,7 +18,7 @@ const Role = ({ data, theme }) => (
       data.members.map(member => (
         <div key={member.fields.handle} className={theme.winner}>
           <a
-            to={`${window.origin}/members/${member.fields.handle}`}
+            href={getMemberProfileUrl(member.fields.handle)}
             target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
           >
             {member.fields.handle}

--- a/src/shared/components/Header/index.jsx
+++ b/src/shared/components/Header/index.jsx
@@ -1,8 +1,12 @@
 import _ from 'lodash';
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import PT from 'prop-types';
 import { config } from 'topcoder-react-utils';
 import Logo from 'assets/images/TC-logo-new.svg';
+import {
+  getMenuWithDirectProfileLink,
+  updateLegacyProfileLinks,
+} from 'utils/url';
 import { tracking } from '../../actions';
 
 import './style.scss';
@@ -23,6 +27,7 @@ const Header = ({
   profile, auth, notifications, loadNotifications, markNotificationAsRead,
   markAllNotificationAsRead, markAllNotificationAsSeen, dismissChallengeNotifications, headerMenu,
 }) => {
+  const headerRef = useRef(null);
   const [activeLevel1Id, setActiveLevel1Id] = useState();
   const [path, setPath] = useState();
   const [openMore, setOpenMore] = useState(true);
@@ -51,9 +56,18 @@ const Header = ({
     normalizedProfile = null;
   }
 
+  const menu = getMenuWithDirectProfileLink(
+    headerMenu || config.HEADER_MENU,
+    profile && profile.handle,
+  );
+
   useEffect(() => {
     setPath(window.location.pathname + window.location.search);
   }, []);
+
+  useEffect(() => {
+    updateLegacyProfileLinks(headerRef.current, profile && profile.handle);
+  }, [profile]);
 
   /*
   * Load Notifications and Init Google Analytics
@@ -71,9 +85,9 @@ const Header = ({
 
   if (TopNavRef) {
     return (
-      <div styleName="nav-header-wrapper">
+      <div ref={headerRef} styleName="nav-header-wrapper">
         <TopNavRef
-          menu={headerMenu || config.HEADER_MENU}
+          menu={menu}
           rightMenu={(
             <LoginNavRef
               loggedIn={!_.isEmpty(profile)}

--- a/src/shared/components/Leaderboard/LeaderboardTable/index.jsx
+++ b/src/shared/components/Leaderboard/LeaderboardTable/index.jsx
@@ -29,6 +29,7 @@ import { Avatar } from 'topcoder-react-ui-kit';
 import { config } from 'topcoder-react-utils';
 import DefaultAvatar from 'assets/images/default-avatar-photo.svg';
 import { getRatingColor } from 'utils/tc';
+import { getMemberProfileUrl } from 'utils/url';
 
 
 import avatarStyles from '../avatarStyles.scss';
@@ -126,7 +127,7 @@ export default function LeaderboardTable(props) {
                 </div>
               ) : (
                 <a
-                  href={`${config.URL.BASE}/members/${competitor['member_profile_basic.handle'] || competitor.handle}/`}
+                  href={getMemberProfileUrl(competitor['member_profile_basic.handle'] || competitor.handle)}
                   target="_blank"
                   rel="noreferrer"
                   style={{ color: rating !== undefined ? getRatingColor(rating) : null }}

--- a/src/shared/components/Leaderboard/PodiumSpot/index.jsx
+++ b/src/shared/components/Leaderboard/PodiumSpot/index.jsx
@@ -32,6 +32,7 @@ import { config } from 'topcoder-react-utils';
 import _ from 'lodash';
 import DefaultAvatar from 'assets/images/default-avatar-photo.svg';
 import { getRatingColor } from 'utils/tc';
+import { getMemberProfileUrl } from 'utils/url';
 
 import avatarStyles from '../avatarStyles.scss';
 import defaultStyles from './themes/styles.scss'; // eslint-disable-line
@@ -164,7 +165,7 @@ export default function PodiumSpot(props) {
         ) : (
           <a
             styleName={`${stylesName}.profile-link`}
-            href={`${window.origin}/members/${competitor['member_profile_basic.handle'] || competitor.handle}/`}
+            href={getMemberProfileUrl(competitor['member_profile_basic.handle'] || competitor.handle)}
             target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
             style={{ color: rating !== undefined ? getRatingColor(rating) : null }}
           >
@@ -261,7 +262,7 @@ export default function PodiumSpot(props) {
               ) : (
                 <a
                   styleName={`${stylesName}.profile-link`}
-                  href={`${window.origin}/members/${competitor['member_profile_basic.handle'] || competitor.handle}/`}
+                  href={getMemberProfileUrl(competitor['member_profile_basic.handle'] || competitor.handle)}
                   target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
                 >
                   {competitor['member_profile_basic.handle'] || competitor.handle}
@@ -287,7 +288,7 @@ export default function PodiumSpot(props) {
                 ) : (
                   <a
                     styleName={`${stylesName}.profile-link`}
-                    href={`${window.origin}/members/${competitor['member_profile_basic.handle'] || competitor.handle}/`}
+                    href={getMemberProfileUrl(competitor['member_profile_basic.handle'] || competitor.handle)}
                     target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
                     style={{ color: rating !== undefined ? getRatingColor(rating) : null }}
                   >

--- a/src/shared/components/Looker/index.jsx
+++ b/src/shared/components/Looker/index.jsx
@@ -22,6 +22,7 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { fixStyle } from 'utils/contentful';
 import { getRatingColor } from 'utils/tc';
+import { getMemberProfileUrl } from 'utils/url';
 import cn from 'classnames';
 import { Scrollbars } from 'react-custom-scrollbars';
 import './style.scss';
@@ -208,7 +209,7 @@ export default class Looker extends Component {
                 return value ? (
                   <td key={cellKey} style={fixStyle(styles)} title={value} styleName="body-row">
                     {memberLinks ? (
-                      <a styleName="handle-link" href={`${window.origin}/members/${value}`} target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`} style={{ color: ratingProp ? getRatingColor(record[ratingProp]) : null }}>
+                      <a styleName="handle-link" href={getMemberProfileUrl(value)} target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`} style={{ color: ratingProp ? getRatingColor(record[ratingProp]) : null }}>
                         {value}
                       </a>
                     ) : value}

--- a/src/shared/components/MMatchLeaderboard/index.jsx
+++ b/src/shared/components/MMatchLeaderboard/index.jsx
@@ -22,6 +22,7 @@ import _ from 'lodash';
 import React, { Component } from 'react';
 import { fixStyle } from 'utils/contentful';
 import { getRatingColor } from 'utils/tc';
+import { getMemberProfileUrl } from 'utils/url';
 import cn from 'classnames';
 import { Scrollbars } from 'react-custom-scrollbars';
 import { config } from 'topcoder-react-utils';
@@ -94,10 +95,10 @@ export default class MMLeaderboard extends Component {
                     <div className={defaultStyles.topMemberPhotoAndPlace}>
                       <img src={member.photoUrl || DEFAULT_AVATAR_URL} className={defaultStyles.topMemberPhoto} alt={`Avatar of ${member.createdBy}`} />
                       <div className={defaultStyles[`topMemberRank${indx + 1}`]}>{member.rank}</div>
-                      <a href={`${config.URL.BASE}/members/${member.createdBy}`} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
+                      <a href={getMemberProfileUrl(member.createdBy)} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
                     </div>
                     <div className={defaultStyles.topMemberLink}>
-                      <a href={`${config.URL.BASE}/members/${member.createdBy}`} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
+                      <a href={getMemberProfileUrl(member.createdBy)} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
                       <p className={defaultStyles.topMemberScore}>{member.score}</p>
                     </div>
                   </div>
@@ -107,10 +108,10 @@ export default class MMLeaderboard extends Component {
                 <div className={defaultStyles.topMemberPhotoAndPlace}>
                   <img src={data[2].photoUrl || DEFAULT_AVATAR_URL} className={defaultStyles.topMemberPhoto} alt={`Avatar of ${data[2].createdBy}`} />
                   <div className={defaultStyles.topMemberRank3}>{data[2].rank}</div>
-                  <a href={`${config.URL.BASE}/members/${data[2].createdBy}`} target="_blank" rel="noreferrer" style={{ color: getRatingColor(data[2].rating) }}>{data[2].createdBy}</a>
+                  <a href={getMemberProfileUrl(data[2].createdBy)} target="_blank" rel="noreferrer" style={{ color: getRatingColor(data[2].rating) }}>{data[2].createdBy}</a>
                 </div>
                 <div className={defaultStyles.topMemberLink}>
-                  <a href={`${config.URL.BASE}/members/${data[2].createdBy}`} target="_blank" rel="noreferrer" style={{ color: getRatingColor(data[2].rating) }}>{data[2].createdBy}</a>
+                  <a href={getMemberProfileUrl(data[2].createdBy)} target="_blank" rel="noreferrer" style={{ color: getRatingColor(data[2].rating) }}>{data[2].createdBy}</a>
                   <p className={defaultStyles.topMemberScore}>{data[2].score}</p>
                 </div>
               </div>
@@ -120,7 +121,7 @@ export default class MMLeaderboard extends Component {
                 {_.slice(data, 3, 7).map(member => (
                   <div className={defaultStyles.follower}>
                     <span>{member.rank}.&nbsp;</span>
-                    <a href={`${config.URL.BASE}/members/${member.createdBy}`} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
+                    <a href={getMemberProfileUrl(member.createdBy)} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
                     <span className={defaultStyles.followerScore}>{member.score}</span>
                   </div>
                 ))}
@@ -131,7 +132,7 @@ export default class MMLeaderboard extends Component {
                   {_.slice(data, 7, 10).map(member => (
                     <div className={defaultStyles.follower}>
                       <span>{member.rank}.&nbsp;</span>
-                      <a href={`${config.URL.BASE}/members/${member.createdBy}`} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
+                      <a href={getMemberProfileUrl(member.createdBy)} target="_blank" rel="noreferrer" style={{ color: getRatingColor(member.rating) }}>{member.createdBy}</a>
                       <span className={defaultStyles.followerScore}>{member.score}</span>
                     </div>
                   ))}
@@ -249,7 +250,7 @@ export default class MMLeaderboard extends Component {
                 }
                 return value ? (
                   <td key={record[prop]} style={fixStyle(styles)} title={value} className={defaultStyles['body-row']}>
-                    {memberLinks ? (<a className={defaultStyles['handle-link']} href={`${window.origin}/members/${value}`} target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}>{value}</a>) : value}
+                    {memberLinks ? (<a className={defaultStyles['handle-link']} href={getMemberProfileUrl(value)} target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}>{value}</a>) : value}
                   </td>
                 ) : null;
               })

--- a/src/shared/components/ProfileBadgesPage/index.jsx
+++ b/src/shared/components/ProfileBadgesPage/index.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import PT from 'prop-types';
-import { Link } from 'react-router-dom';
 import { get } from 'lodash';
 import { Modal } from 'topcoder-react-ui-kit';
 import IconClose from 'assets/images/tc-edu/icon-close-big.svg';
 import FallBackAwardIcon from 'assets/images/default-award.svg';
 import md from 'utils/markdown';
+import { getMemberProfileUrl } from 'utils/url';
 import { format } from 'date-fns';
 import AwardModal from '../ProfilePage/Awards/AwardModal';
 
@@ -17,8 +17,8 @@ const ProfileBadges = ({ badges, handleParam }) => {
 
   return (
     <div styleName="outer-container">
-      <Link
-        to={`/members/${handleParam}`}
+      <a
+        href={getMemberProfileUrl(handleParam)}
         styleName="memberPageBackLink"
       >
         <svg
@@ -36,7 +36,7 @@ const ProfileBadges = ({ badges, handleParam }) => {
           />
         </svg>
         Return to Profile
-      </Link>
+      </a>
       <div styleName="badgesWrap">
         <div styleName="seactionTitle">COMMUNITY AWARDS & HONORS</div>
         <div styleName="badgesGrid">

--- a/src/shared/components/ReviewOpportunityDetailsPage/ApplicationsTab/index.jsx
+++ b/src/shared/components/ReviewOpportunityDetailsPage/ApplicationsTab/index.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 import React from 'react';
 import PT from 'prop-types';
 import _ from 'lodash';
+import { getMemberProfileUrl } from 'utils/url';
 
 import './styles.scss';
 
@@ -33,7 +34,7 @@ const ApplicationsTab = ({ applications }) => (
         && applications.filter(app => app.status !== 'CANCELLED').map(app => (
           <div styleName="row" key={`${app.handle} ${app.role}`}>
             <div styleName="col-1">
-              <a href={`${window.origin}/members/${app.handle}`} target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}>
+              <a href={getMemberProfileUrl(app.handle)} target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}>
                 {app.handle}
               </a>
             </div>

--- a/src/shared/components/challenge-detail/Registrants/index.jsx
+++ b/src/shared/components/challenge-detail/Registrants/index.jsx
@@ -10,6 +10,7 @@ import _ from 'lodash';
 import cn from 'classnames';
 import { getRatingLevel } from 'utils/tc';
 import { getTrackName } from 'utils/challenge';
+import { getMemberProfileUrl } from 'utils/url';
 
 import sortList from 'utils/challenge-detail/sort';
 import DateSortIcon from 'assets/images/icon-date-sort.svg';
@@ -464,7 +465,7 @@ export default class Registrants extends React.Component {
                      </div>
                      <span role="cell">
                        <a
-                         href={`${window.origin}/members/${r.memberHandle}`}
+                         href={getMemberProfileUrl(r.memberHandle)}
                          styleName={isDesign ? '' : `level-${getRatingLevel(_.get(r, 'rating', 0))}`}
                          target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
                        >

--- a/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/SubmissionRow/index.jsx
@@ -7,6 +7,7 @@ import React from 'react';
 import PT from 'prop-types';
 import _ from 'lodash';
 import { CHALLENGE_STATUS, getRatingLevel } from 'utils/tc';
+import { getMemberProfileUrl } from 'utils/url';
 import { Modal } from 'topcoder-react-ui-kit';
 import IconClose from 'assets/images/icon-close-green.svg';
 import moment from 'moment';
@@ -123,7 +124,7 @@ export default function SubmissionRow({
   const ratingLevelStyle = `col level-${getRatingLevel(rating)}`;
   const memberHandle = member || '';
   const memberDisplay = memberHandle || '-';
-  const memberProfileUrl = memberHandle ? `${window.origin}/members/${memberHandle}` : null;
+  const memberProfileUrl = memberHandle ? getMemberProfileUrl(memberHandle) : null;
   const memberLinkTarget = `${_.includes(window.origin, 'www') ? '_self' : '_blank'}`;
   const memberForHistory = memberHandle || memberDisplay;
   const latestSubmissionId = latestSubmission.submissionId || latestSubmission.id || 'N/A';

--- a/src/shared/components/challenge-detail/Submissions/index.jsx
+++ b/src/shared/components/challenge-detail/Submissions/index.jsx
@@ -25,6 +25,7 @@ import { shouldShowFinalMmResults as resolveShouldShowFinalMmResults } from 'uti
 import { getSubmissionId } from 'utils/submissions';
 import { compressFiles } from 'utils/files';
 import { buildMmSubmissionData } from 'utils/mm-review-summations';
+import { getMemberProfileUrl } from 'utils/url';
 import { getChallengeSubmissions as getChallengeSubmissionsService } from 'services/submissions';
 
 import sortList from 'utils/challenge-detail/sort';
@@ -1008,7 +1009,7 @@ class SubmissionsComponent extends React.Component {
               {`#${s.id}`}
             </a>
             <a
-              href={`${window.origin}/members/${_.get(s.registrant, 'memberHandle', '')}`}
+              href={getMemberProfileUrl(_.get(s.registrant, 'memberHandle', ''))}
               target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
               rel="noopener noreferrer"
               styleName={`level-${getRatingLevel(_.get(s.registrant, 'rating', 0))}`}

--- a/src/shared/components/challenge-detail/Winners/Winner/index.jsx
+++ b/src/shared/components/challenge-detail/Winners/Winner/index.jsx
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import { config } from 'topcoder-react-utils';
 import { formatOrdinals, numberWithCommas } from 'utils/challenge-detail/helper';
 import { getMMSubmissionId } from 'utils/submissions';
+import { getMemberProfileUrl } from 'utils/url';
 import DownloadIcon from '../../../SubmissionManagement/Icons/IconSquareDownload.svg';
 
 import style from './style.scss';
@@ -75,7 +76,7 @@ export default function Winner({
             />
             <div>
               <a
-                href={`${windowOrigin}/members/${winner.handle}`}
+                href={getMemberProfileUrl(winner.handle)}
                 styleName="handle"
                 target={`${_.includes(windowOrigin, 'www') ? '_self' : '_blank'}`}
               >

--- a/src/shared/components/challenge-listing/LeaderboardAvatar/index.jsx
+++ b/src/shared/components/challenge-listing/LeaderboardAvatar/index.jsx
@@ -5,6 +5,7 @@ import PT from 'prop-types';
 import { config, Link } from 'topcoder-react-utils';
 import _ from 'lodash';
 import { formatOrdinals } from 'utils/challenge-listing/helper';
+import { getMemberProfileUrl } from 'utils/url';
 import './style.scss';
 
 /* TODO: Should be functional component! */
@@ -21,7 +22,7 @@ class LeaderboardAvatar extends Component {
       onClick, plusOne, url,
     } = this.props;
     const { member } = this.state;
-    const targetURL = url || `${window.origin}/members/${member.handle}`;
+    const targetURL = url || getMemberProfileUrl(member.handle);
     let { photoURL } = member;
     if (photoURL) {
       /* Note: 50px is larger than we really need here (the avatar size is

--- a/src/shared/components/tc-communities/Header/index.jsx
+++ b/src/shared/components/tc-communities/Header/index.jsx
@@ -19,6 +19,7 @@ import {
   isomorphy,
 } from 'topcoder-react-utils';
 import { getRatingColor } from 'utils/tc';
+import { getMemberProfileUrl } from 'utils/url';
 import Dropdown from 'components/tc-communities/Dropdown';
 import { themr } from 'react-css-super-themr';
 import Menu from 'components/Contentful/Menu';
@@ -74,7 +75,7 @@ function Header(props) {
   let userSubMenu;
 
   if (profile) {
-    let profileLink = `${meta ? _.replace(BASE_URL, 'www', meta.subdomains[0]) : BASE_URL}/members/${normalizedProfile.handle}`;
+    let profileLink = getMemberProfileUrl(normalizedProfile.handle);
     let paymentsLink = `${config.URL.COMMUNITY}/PactsMemberServlet?module=PaymentHistory&full_list=false`;
 
     // Handle Wipro specific links (PS-257)

--- a/src/shared/components/tc-communities/communities/blockchain/BsicHackathon/index.jsx
+++ b/src/shared/components/tc-communities/communities/blockchain/BsicHackathon/index.jsx
@@ -1,6 +1,7 @@
 import JoinCommunity from 'containers/tc-communities/JoinCommunity';
 import React from 'react';
 import { Link } from 'topcoder-react-utils';
+import { getMemberProfileUrl } from 'utils/url';
 
 import HeadBannerImage from
   'assets/images/communities/blockchain/bsic-hackathon/head-banner.jpg';
@@ -187,42 +188,42 @@ export default function BsicHackathon() {
                     Trevor Campbell (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/tdcampbell/"
+                      to={getMemberProfileUrl('tdcampbell')}
                     >
                       tdcampbell
                     </Link>
                     ), Todd Schultz (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/tschultz1216/"
+                      to={getMemberProfileUrl('tschultz1216')}
                     >
                       tschultz1216
                     </Link>
                     ), Sam Blumenthal (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/sam.blumenthal/"
+                      to={getMemberProfileUrl('sam.blumenthal')}
                     >
                       sam.blumenthal
                     </Link>
                     ), Gurmeet Budhraja (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/khojsolutions/"
+                      to={getMemberProfileUrl('khojsolutions')}
                     >
                       khojsolutions
                     </Link>
                     ), Madhu Machavarapu (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/94madhu94/"
+                      to={getMemberProfileUrl('94madhu94')}
                     >
                       94madhu94
                     </Link>
                     ), Urja Pawar (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/urjapawar/"
+                      to={getMemberProfileUrl('urjapawar')}
                     >
                       urjapawar
                     </Link>
@@ -253,21 +254,21 @@ export default function BsicHackathon() {
                     Elisa Pasquali (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/epg/"
+                      to={getMemberProfileUrl('epg')}
                     >
                       epg
                     </Link>
                     ), Ana Zamfir (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/ancaz/"
+                      to={getMemberProfileUrl('ancaz')}
                     >
                       ancaz
                     </Link>
                     ), Ioana Stanescu (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/osninja/"
+                      to={getMemberProfileUrl('osninja')}
                     >
                       osninja
                     </Link>
@@ -318,14 +319,14 @@ export default function BsicHackathon() {
                     Val Denay Mack (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/valem21/"
+                      to={getMemberProfileUrl('valem21')}
                     >
                       valem21
                     </Link>
                     ), Gael Gundin (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/wapinpana/"
+                      to={getMemberProfileUrl('wapinpana')}
                     >
                       wapinpana
                     </Link>
@@ -356,42 +357,42 @@ export default function BsicHackathon() {
                     Rahul Bansal (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/rahulb/"
+                      to={getMemberProfileUrl('rahulb')}
                     >
                       rahulb
                     </Link>
                     ), Siddharth Swarnkar (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/siddharthsoni/"
+                      to={getMemberProfileUrl('siddharthsoni')}
                     >
                       siddharthsoni
                     </Link>
                     ), Sundari Narayan Swami (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/sswami/"
+                      to={getMemberProfileUrl('sswami')}
                     >
                       sswami
                     </Link>
                     ), Bhavyaa Rastogi (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/krusherz/"
+                      to={getMemberProfileUrl('krusherz')}
                     >
                       krusherz
                     </Link>
                     ), Carlos Rojas Noveron (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/CarlosNoveron/"
+                      to={getMemberProfileUrl('CarlosNoveron')}
                     >
                       CarlosNoveron
                     </Link>
                     ), Dr. Hugh Gosnell (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/hugh_g/"
+                      to={getMemberProfileUrl('hugh_g')}
                     >
                       hugh_g
                     </Link>
@@ -441,42 +442,42 @@ export default function BsicHackathon() {
                     Sajida Zouarhi (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/sajz/"
+                      to={getMemberProfileUrl('sajz')}
                     >
                       SajZ
                     </Link>
                     ), Noah Basri (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/noah-basri/"
+                      to={getMemberProfileUrl('noah-basri')}
                     >
                       Noah-Basri
                     </Link>
                     ), Maroussia Arnault (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/marou_kid/"
+                      to={getMemberProfileUrl('marou_kid')}
                     >
                       Marou_Kid
                     </Link>
                     ), Amelia Lintern-Smith (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/amelials/"
+                      to={getMemberProfileUrl('amelials')}
                     >
                       amelials
                     </Link>
                     ), Clément Massonnaud (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/clemass/"
+                      to={getMemberProfileUrl('clemass')}
                     >
                       CleMass
                     </Link>
                     ), Mathieu Vincens (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/Mathvincens/"
+                      to={getMemberProfileUrl('Mathvincens')}
                     >
                       Mathvincens
                     </Link>
@@ -507,35 +508,35 @@ export default function BsicHackathon() {
                     Alexander S. Blum (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/ablumbc/"
+                      to={getMemberProfileUrl('ablumbc')}
                     >
                       ablumbc
                     </Link>
                     ), Meredith Finkelstein (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/msrobot0/"
+                      to={getMemberProfileUrl('msrobot0')}
                     >
                       msrobot0
                     </Link>
                     ), Seth Weiner (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/sethweiner/"
+                      to={getMemberProfileUrl('sethweiner')}
                     >
                       sethweiner
                     </Link>
                     ), Chris Jaroszewski (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/CJaroszewski/"
+                      to={getMemberProfileUrl('CJaroszewski')}
                     >
                       Cjaroszewski
                     </Link>
                     ) , Peter Lyons (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/anemas971/"
+                      to={getMemberProfileUrl('anemas971')}
                     >
                       Anemas971
                     </Link>
@@ -590,21 +591,21 @@ export default function BsicHackathon() {
                     Philipp Beer (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/Depose/"
+                      to={getMemberProfileUrl('Depose')}
                     >
                       Depose
                     </Link>
                     ), Lewis Daly (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/lwilld/"
+                      to={getMemberProfileUrl('lwilld')}
                     >
                       lwilld
                     </Link>
                     ), Billy Garrison (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/BillyGarrison/"
+                      to={getMemberProfileUrl('BillyGarrison')}
                     >
                       BillyGarrison
                     </Link>
@@ -632,42 +633,42 @@ export default function BsicHackathon() {
                     Ylli Vllasolli (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/Team-Thor/"
+                      to={getMemberProfileUrl('Team-Thor')}
                     >
                       Team-Thor
                     </Link>
                     ), Charlotte Stephens (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/Charlotte-Thor/"
+                      to={getMemberProfileUrl('Charlotte-Thor')}
                     >
                       Charlotte-Thor
                     </Link>
                     ), Bayo Akins (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/BayoAkins/"
+                      to={getMemberProfileUrl('BayoAkins')}
                     >
                       Bayoakins
                     </Link>
                     ), Erica Sundberg (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/e5r34t/"
+                      to={getMemberProfileUrl('e5r34t')}
                     >
                       e5r34t
                     </Link>
                     ), Stephen Jackson (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/stevejaxon/"
+                      to={getMemberProfileUrl('stevejaxon')}
                     >
                       stevejaxon
                     </Link>
                     ), Ife Nkechukwu (
                     <Link
                       openNewTab
-                      to="https://www.topcoder.com/members/ife-thor/"
+                      to={getMemberProfileUrl('ife-thor')}
                     >
                       ife-thor
                     </Link>

--- a/src/shared/components/tc-communities/communities/iot/AssetDetail/index.jsx
+++ b/src/shared/components/tc-communities/communities/iot/AssetDetail/index.jsx
@@ -6,6 +6,7 @@
 import Error404 from 'components/Error404';
 import React from 'react';
 import PT from 'prop-types';
+import { getMemberProfileUrl } from 'utils/url';
 
 import { PrimaryButton } from 'topcoder-react-ui-kit';
 
@@ -21,6 +22,10 @@ export default function AssetDetail({
 }) {
   const assets = assetsData.filter(item => item.id === assetId);
   const asset = assets[0];
+  const abstract = asset && asset.abstract.replace(
+    /https:\/\/www\.topcoder\.com\/members\/([^/'"]+)\/?/g,
+    (_legacyUrl, handle) => getMemberProfileUrl(handle),
+  );
   return (
     typeof asset === 'undefined'
       ? <Error404 />
@@ -37,7 +42,7 @@ export default function AssetDetail({
               <h2>
                 Asset Details
               </h2>
-              <div dangerouslySetInnerHTML={{ __html: asset.abstract }} />
+              <div dangerouslySetInnerHTML={{ __html: abstract }} />
               <p>
                 <a href={asset.githubUrl} styleName="github">
                   { asset.githubUrl }
@@ -59,7 +64,7 @@ export default function AssetDetail({
                     Topcoder Winner
                   </h4>
 
-                  <a href={asset.author.profileURL} target="_blank" rel="noreferrer noopener">
+                  <a href={getMemberProfileUrl(asset.author.name)} target="_blank" rel="noreferrer noopener">
                     { asset.author.name }
                   </a>
                   <div>

--- a/src/shared/components/tco/scoreboard/ScoreboardTable/index.jsx
+++ b/src/shared/components/tco/scoreboard/ScoreboardTable/index.jsx
@@ -21,6 +21,7 @@
 import React from 'react';
 import PT from 'prop-types';
 import _ from 'lodash';
+import { getMemberProfileUrl } from 'utils/url';
 
 import codeFields from 'shared/fields/submissionCodeFields.json';
 import designFields from 'shared/fields/submissionDesignFields.json';
@@ -53,7 +54,7 @@ export default function ScoreboardTable(props) {
           </td>
           <td styleName="styles.col-handle">
             <a
-              href={`${window.origin}/members/${submission.handle}/`}
+              href={getMemberProfileUrl(submission.handle)}
               target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
             >
               {submission.handle}

--- a/src/shared/containers/Contentful/MenuLoader/index.jsx
+++ b/src/shared/containers/Contentful/MenuLoader/index.jsx
@@ -12,6 +12,10 @@ import { connect } from 'react-redux';
 import Logo from 'assets/images/tc-logo.svg';
 import { isomorphy, config } from 'topcoder-react-utils';
 import actions from 'actions/contentful';
+import {
+  getMenuWithDirectProfileLink,
+  updateLegacyProfileLinks,
+} from 'utils/url';
 
 
 class MenuLoaderContainer extends React.Component {
@@ -51,6 +55,18 @@ class MenuLoaderContainer extends React.Component {
         baseUrl,
       });
     }
+    this.refreshProfileLinks();
+  }
+
+  componentDidUpdate() {
+    this.refreshProfileLinks();
+  }
+
+  refreshProfileLinks() {
+    const { auth } = this.props;
+    if (isomorphy.isClientSide()) {
+      updateLegacyProfileLinks(document, _.get(auth, 'profile.handle'));
+    }
   }
 
   handleChangeLevel1Id(menuId) {
@@ -87,12 +103,16 @@ class MenuLoaderContainer extends React.Component {
       } else {
         normalizedProfile = null;
       }
+      const menuWithDirectProfileLink = getMenuWithDirectProfileLink(
+        menu,
+        _.get(auth, 'profile.handle'),
+      );
       if (fields.theme.indexOf('TCO22') !== -1) {
         // eslint-disable-next-line global-require
         const { TopNav: TopNavTCO, LoginNav: LoginNavTCO } = require('navigation-component-tco');
         return (
           <TopNavTCO
-            menu={menu}
+            menu={menuWithDirectProfileLink}
             rightMenu={(
               <LoginNavTCO
                 loggedIn={!_.isEmpty(auth.profile)}
@@ -126,7 +146,7 @@ class MenuLoaderContainer extends React.Component {
       const { TopNav, LoginNav } = require('navigation-component');
       return (
         <TopNav
-          menu={menu}
+          menu={menuWithDirectProfileLink}
           rightMenu={(
             <LoginNav
               loggedIn={!_.isEmpty(auth.profile)}

--- a/src/shared/containers/Gamification/index.jsx
+++ b/src/shared/containers/Gamification/index.jsx
@@ -11,6 +11,7 @@ import YouGotSkillsModal from 'components/Gamification/YouGotSkillsModal';
 import { keys } from 'lodash';
 import cookies from 'browser-cookies';
 import { actions } from 'topcoder-react-lib';
+import { getMemberProfileUrl } from 'utils/url';
 
 const REMIND_TIME_COOKIE_NAME = 'tc_skills_remind_time';
 const REMIND_TIME = 604800000; // a week
@@ -98,7 +99,7 @@ class GamificationContainer extends React.Component {
       ...profile,
     });
     // Send them to profile page
-    window.location = `/members/${auth.user.handle}`;
+    window.location = getMemberProfileUrl(auth.user.handle);
   }
 
   onYouGotSkillsModalCancel() {

--- a/src/shared/containers/Profile.jsx
+++ b/src/shared/containers/Profile.jsx
@@ -14,6 +14,7 @@ import Error404 from 'components/Error404';
 import LoadingIndicator from 'components/LoadingIndicator';
 import ProfilePage from 'components/ProfilePage';
 import { loadPublicStatsOnly } from 'utils/memberStats';
+import { getMemberProfileUrl } from 'utils/url';
 
 // how many challenges to query per batch
 const CHALLENGE_PER_PAGE = 36;
@@ -100,7 +101,7 @@ class ProfileContainer extends React.Component {
         if (profileConfig && profileConfig.userProfile
           && memberGroups.indexOf(profileConfig.groupId) === -1) {
           if (window.location.href.indexOf(profileConfig.communityName) !== -1) {
-            window.location.href = `${config.URL.BASE}/members/${handleParam}`;
+            window.location.href = getMemberProfileUrl(handleParam);
           }
           return false;
         }

--- a/src/shared/containers/tc-communities/tco20/Header.jsx
+++ b/src/shared/containers/tc-communities/tco20/Header.jsx
@@ -7,7 +7,7 @@ import { Link, config } from 'topcoder-react-utils';
 import { connect } from 'react-redux';
 import { Avatar } from 'topcoder-react-ui-kit';
 import MediaQuery from 'react-responsive';
-import { getCurrentUrl } from 'utils/url';
+import { getCurrentUrl, getMemberProfileUrl } from 'utils/url';
 import TCO20Logo from 'assets/themes/tco/TCO20.svg';
 import defaultStyle from './header.scss';
 
@@ -18,7 +18,10 @@ function TCO20Header(props) {
       {
         auth && auth.profile ? (
           <React.Fragment>
-            <Link to={`${base}/members/${auth.profile.handle}`} className={defaultStyle.userMenuHandle}>
+            <Link
+              to={getMemberProfileUrl(auth.profile.handle)}
+              className={defaultStyle.userMenuHandle}
+            >
               {auth.profile.handle}
             </Link>
             <Avatar url={auth.profile.photoURL} />

--- a/src/shared/containers/timeline-wall/pending-approvals/approval-item/index.jsx
+++ b/src/shared/containers/timeline-wall/pending-approvals/approval-item/index.jsx
@@ -11,7 +11,7 @@ import ModalDeleteConfirmation from '../../modal-delete-confirmation';
 import ModalPhotoViewer from '../../modal-photo-viewer';
 
 import './styles.scss';
-import { DEFAULT_AVATAR_URL } from '../../../../utils/url';
+import { DEFAULT_AVATAR_URL, getMemberProfileUrl } from '../../../../utils/url';
 
 function ApprovalItem({
   className, event, removeEvent, userAvatars, deleteEvent, onApproveEvent,
@@ -36,7 +36,7 @@ function ApprovalItem({
               <div styleName="separator" />
               <img width="24" height="24" src={photoURL} alt="avatar" />
               <a
-                href={`${window.origin}/members/${event.createdBy}`}
+                href={getMemberProfileUrl(event.createdBy)}
                 target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
                 rel="noopener noreferrer"
                 styleName="text-handle"

--- a/src/shared/containers/timeline-wall/timeline-events/events/event-item/index.jsx
+++ b/src/shared/containers/timeline-wall/timeline-events/events/event-item/index.jsx
@@ -13,7 +13,7 @@ import ModalPhotoViewer from '../../../modal-photo-viewer';
 import PhotoItemsMobile from '../../../photo-items-mobile';
 import ModalDeleteConfirmation from '../../../modal-delete-confirmation';
 import './styles.scss';
-import { DEFAULT_AVATAR_URL } from '../../../../../utils/url';
+import { DEFAULT_AVATAR_URL, getMemberProfileUrl } from '../../../../../utils/url';
 
 function EventItem({
   className, isLeft, eventItem, deleteEvent, isAdmin, userAvatars, idPrefix,
@@ -86,7 +86,7 @@ function EventItem({
             <img width="23" height="23" src={photoURL} alt="avatar" />
             <a
               styleName="text-handle"
-              href={`${window.origin}/members/${eventItem.createdBy}`}
+              href={getMemberProfileUrl(eventItem.createdBy)}
               target={`${_.includes(window.origin, 'www') ? '_self' : '_blank'}`}
               rel="noopener noreferrer"
             >{eventItem.createdBy}

--- a/src/shared/utils/url.js
+++ b/src/shared/utils/url.js
@@ -147,6 +147,61 @@ export function removeTrailingSlash(url) {
 }
 
 /**
+ * Get the direct URL for a member profile.
+ *
+ * @param {String} handle Topcoder member handle.
+ * @return {String} URL of the member's profile in the configured environment.
+ */
+export function getMemberProfileUrl(handle) {
+  return `${config.MEMBER_PROFILE_REDIRECT_URL}/${handle}`;
+}
+
+/**
+ * Point the profile entry in a navigation menu directly to the profile app.
+ * The id is changed because navigation-component replaces "myprofile" URLs
+ * with its legacy /members/:handle route.
+ *
+ * @param {Array} menu Navigation menu configuration.
+ * @param {String} handle Topcoder member handle.
+ * @return {Array} Navigation menu with a direct member profile link.
+ */
+export function getMenuWithDirectProfileLink(menu, handle) {
+  if (!handle) return menu;
+
+  return menu.map(item => (item.secondaryMenu ? {
+    ...item,
+    secondaryMenu: item.secondaryMenu.map(secondaryItem => (
+      ['myprofile', 'profile'].includes(secondaryItem.id)
+        ? {
+          ...secondaryItem,
+          id: 'profile',
+          href: getMemberProfileUrl(handle),
+        }
+        : secondaryItem
+    )),
+  } : item));
+}
+
+/**
+ * Update exact legacy profile anchors rendered by navigation-component.
+ *
+ * @param {Element|Document} root Root node containing navigation links.
+ * @param {String} handle Topcoder member handle.
+ * @return {void}
+ */
+export function updateLegacyProfileLinks(root, handle) {
+  if (!root || !handle) return;
+
+  const legacyProfilePath = `/members/${handle}`;
+  _.forEach(root.querySelectorAll('a[href]'), (link) => {
+    const href = link.getAttribute('href');
+    if (href && href.replace(/\/$/, '') === legacyProfilePath) {
+      link.setAttribute('href', getMemberProfileUrl(handle));
+    }
+  });
+}
+
+/**
  * Get Payment page url from header menu.
  *
  * @return {String}


### PR DESCRIPTION
## Summary

- Send member-handle links directly to the environment-specific Profiles app.
- Normalize header menu and account links produced by the legacy navigation dependencies.
- Update snapshots, URL helper coverage, and browser smoke-test expectations.

## Root cause

Community App still generated `/members/:handle` links and depended on the legacy Topcoder redirect. When that redirect failed, profile navigation failed with it.

## Impact

Profile clicks now go directly to `profiles.topcoder.com/:handle` in production and `profiles.topcoder-dev.com/:handle` in non-production environments. Existing API requests and legacy badge/detail routes remain unchanged.

## Validation

- Full Jest suite under the repository's Node 10 runtime: 154 suites passed, 347 tests passed, 141 snapshots passed.
- ESLint passed for all changed application JavaScript/JSX files.
- JSON validation passed for the updated smoke-test environment configs.
- Verified the commit merges without conflicts and produces the same focused diff against both `develop` and `master`.
- Smoke-test TypeScript compile was not run because that subproject's dependencies are not installed locally.
