### PR TITLE
PM-5895: send auth token when loading review opportunities

### DIFF
--- a/__tests__/shared/services/reviewOpportunities.js
+++ b/__tests__/shared/services/reviewOpportunities.js
@@ -1,4 +1,4 @@
-import { getDetails } from 'services/reviewOpportunities';
+import getReviewOpportunities, { getDetails } from 'services/reviewOpportunities';
 
 describe('shared/services/reviewOpportunities.getDetails', () => {
   let originalFetch;
@@ -97,5 +97,68 @@ describe('shared/services/reviewOpportunities.getDetails', () => {
     await expect(getDetails('12345', 'opp-3')).rejects.toThrow(
       'Failed to load review opportunity: Not Found',
     );
+  });
+});
+
+describe('shared/services/reviewOpportunities auth token forwarding', () => {
+  let originalFetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    jest.clearAllMocks();
+  });
+
+  test('sends the auth token when listing review opportunities', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    await getReviewOpportunities(0, 10, 'token-v3');
+
+    expect(global.fetch).toHaveBeenCalledWith(expect.any(String), {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token-v3' },
+    });
+  });
+
+  test('omits the authorization header for anonymous listing requests', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve([]),
+    });
+
+    await getReviewOpportunities(0, 10);
+
+    expect(global.fetch).toHaveBeenCalledWith(expect.any(String), {
+      method: 'GET',
+      headers: {},
+    });
+  });
+
+  test('sends the auth token when loading review opportunity details', async () => {
+    global.fetch = jest.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ result: { content: { id: 'opp-4' } } }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: '12345' }),
+      });
+
+    await getDetails('12345', 'opp-4', 'token-v3');
+
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    global.fetch.mock.calls.forEach(([, options]) => {
+      expect(options).toEqual({
+        method: 'GET',
+        headers: { Authorization: 'Bearer token-v3' },
+      });
+    });
   });
 });

--- a/src/shared/actions/challenge-listing/index.js
+++ b/src/shared/actions/challenge-listing/index.js
@@ -488,11 +488,12 @@ function getPastChallengesDone(uuid, page, backendFilter, tokenV3, frontFilter =
  * Action to get a list of currently open Review Opportunities using V3 API
  * @param {String} uuid Unique identifier for init/donen instance from shortid module
  * @param {Number} page Page of review opportunities to fetch.
- * @param {String} tokenV3 Optional. Topcoder auth token v3.
+ * @param {String} tokenV3 Optional. Topcoder auth token v3. Required for the
+ *  API to return opportunities of group restricted (private) challenges.
  * @return {Object} Action object
  */
-function getReviewOpportunitiesDone(uuid, page) {
-  return getReviewOpportunities(page, REVIEW_OPPORTUNITY_PAGE_SIZE)
+function getReviewOpportunitiesDone(uuid, page, tokenV3) {
+  return getReviewOpportunities(page, REVIEW_OPPORTUNITY_PAGE_SIZE, tokenV3)
     .then(loaded => ({ uuid, loaded }))
     .catch((error) => {
       fireErrorMessage('Error Getting Review Opportunities', error.content || error);

--- a/src/shared/actions/page/review-opportunity-details.js
+++ b/src/shared/actions/page/review-opportunity-details.js
@@ -28,11 +28,12 @@ function getDetailsInit() {}
  *  the specified challenge.
  * @param {Number} challengeId The ID of the challenge (not the opportunity id)
  * @param {Number} opportunityId The ID of the review opportunity
- * @param {String} tokenV3=null Optional. Topcoder auth token v3.
+ * @param {String} tokenV3=null Optional. Topcoder auth token v3. Required for
+ *  the API to serve opportunities of group restricted (private) challenges.
  * @return {Action}
  */
-function getDetailsDone(challengeId, opportunityId) {
-  return getDetails(challengeId, opportunityId)
+function getDetailsDone(challengeId, opportunityId, tokenV3) {
+  return getDetails(challengeId, opportunityId, tokenV3)
     .then(details => ({ details }))
     .catch((error) => {
       if (error.status !== 401) {

--- a/src/shared/containers/challenge-listing/Listing/index.jsx
+++ b/src/shared/containers/challenge-listing/Listing/index.jsx
@@ -603,6 +603,7 @@ export class ListingContainer extends React.Component {
     if (!allReviewOpportunitiesLoaded) {
       loadMoreReviewOpportunities = () => getReviewOpportunities(
         1 + lastRequestedPageOfReviewOpportunities,
+        tokenV3,
       );
     }
 
@@ -1001,10 +1002,10 @@ function mapDispatchToProps(dispatch) {
       dispatch(a.getPastChallengesInit(uuid, page, frontFilter));
       dispatch(a.getPastChallengesDone(uuid, page, filter, token, frontFilter));
     },
-    getReviewOpportunities: (page) => {
+    getReviewOpportunities: (page, tokenV3) => {
       const uuid = shortId();
       dispatch(a.getReviewOpportunitiesInit(uuid, page));
-      dispatch(a.getReviewOpportunitiesDone(uuid, page));
+      dispatch(a.getReviewOpportunitiesDone(uuid, page, tokenV3));
     },
     getCopilotOpportunities: (page) => {
       const uuid = shortId();

--- a/src/shared/services/reviewOpportunities.js
+++ b/src/shared/services/reviewOpportunities.js
@@ -28,20 +28,37 @@ function buildChallengeFallback(opportunity, challengeId) {
 }
 
 /**
- * Fetches copilot opportunities.
+ * Builds the request options for review opportunity reads.
+ * The token must be forwarded so that the API can evaluate the caller against
+ * the groups of private challenges; anonymous calls only receive opportunities
+ * of public challenges.
+ *
+ * @param {String} tokenV3 Optional. Topcoder auth token v3.
+ * @returns {Object} Fetch options for a GET request.
+ */
+function getRequestOptions(tokenV3) {
+  return {
+    method: 'GET',
+    headers: tokenV3 ? { Authorization: `Bearer ${tokenV3}` } : {},
+  };
+}
+
+/**
+ * Fetches review opportunities.
  *
  * @param {number} page - Page number (1-based).
  * @param {number} pageSize - Number of items per page.
+ * @param {String} tokenV3 - Optional. Topcoder auth token v3.
  * @returns {Promise<Object>} The fetched data.
  */
-export default async function getReviewOpportunities(page, pageSize) {
+export default async function getReviewOpportunities(page, pageSize, tokenV3) {
   const offset = page * pageSize;
 
   const url = new URL(`${v6ApiUrl}/review-opportunities`);
   url.searchParams.append('limit', pageSize);
   url.searchParams.append('offset', offset);
 
-  const res = await fetch(url.toString(), { method: 'GET' });
+  const res = await fetch(url.toString(), getRequestOptions(tokenV3));
 
   if (!res.ok) {
     throw new Error(res.statusText);
@@ -56,16 +73,19 @@ export default async function getReviewOpportunities(page, pageSize) {
 /**
    * Gets the details of the review opportunity for the corresponding challenge
    * @param {Number} challengeId The ID of the challenge (not the opportunity id)
+   * @param {Number} opportunityId The ID of the review opportunity
+   * @param {String} tokenV3 Optional. Topcoder auth token v3.
    * @return {Object} The combined data of the review opportunity and challenge details
    */
-export async function getDetails(challengeId, opportunityId) {
+export async function getDetails(challengeId, opportunityId, tokenV3) {
   const getReviewOpportunityUrl = new URL(`${v6ApiUrl}/review-opportunities/${opportunityId}`);
   const getChallengeUrl = new URL(`${v6ApiUrl}/challenges/${challengeId}`);
+  const options = getRequestOptions(tokenV3);
 
   try {
     const [opportunityRes, challengeRes] = await Promise.all([
-      fetch(getReviewOpportunityUrl.toString(), { method: 'GET' }),
-      fetch(getChallengeUrl.toString(), { method: 'GET' }),
+      fetch(getReviewOpportunityUrl.toString(), options),
+      fetch(getChallengeUrl.toString(), options),
     ]);
 
     if (!opportunityRes.ok) {


### PR DESCRIPTION
## What was broken

Private (group restricted) challenges were listed in the **Open for Review** bucket of the community app Opportunities page for anonymous visitors and for members who are not part of the challenge group.

After the review API started enforcing group visibility, the opposite problem showed up (see the comment on PM-5895): the review opportunities of group challenges stopped being visible to admins and to members of those groups as well.

## Root cause

The community app called the v6 review opportunity endpoints without an `Authorization` header:

- `GET /v6/review-opportunities`
- `GET /v6/review-opportunities/{opportunityId}`

Both endpoints evaluate challenge group access against the calling user, so every community app request was treated as anonymous. An anonymous caller only receives opportunities of public challenges, so group challenges could never be shown to the admins and group members who are entitled to see them — while older API builds that did not filter at all exposed them to everyone.

## What was changed

- `src/shared/services/reviewOpportunities.js` — added a shared `getRequestOptions` helper that attaches `Authorization: Bearer <tokenV3>` when a token is available, and used it for both the listing and the details requests.
- `src/shared/actions/challenge-listing/index.js` — `getReviewOpportunitiesDone` accepts `tokenV3` and forwards it to the service.
- `src/shared/containers/challenge-listing/Listing/index.jsx` — the load-more handler and the `mapDispatchToProps` binding pass the logged in user's `tokenV3`.
- `src/shared/actions/page/review-opportunity-details.js` — `getDetailsDone` forwards the `tokenV3` that the details container was already dispatching.

No API change was required. `review-api-v6` already filters challenge ids by challenge groups and bypasses that filter for admin/M2M callers. This was verified against `api.topcoder-dev.com`: for a grouped challenge with an OPEN review opportunity, the search endpoint returns the opportunity for an M2M caller and returns nothing for an anonymous caller, and `/review-opportunities/challenge/{id}` returns `403 FORBIDDEN_CHALLENGE_WHITELIST` anonymously.

## Any added/updated tests

- `__tests__/shared/services/reviewOpportunities.js` — new `auth token forwarding` suite:
  - the `Authorization` header is sent when listing review opportunities with a token,
  - the header is omitted for anonymous listing requests,
  - both details requests carry the header when a token is supplied.

Commands run: `npm run jest -- __tests__/shared/services/reviewOpportunities.js` (6 passed), `npm run lint:js` (clean), `npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
