### PR TITLE
PM-5961: only allow deleting submissions while their submission phase is open

### DIFF
--- a/__tests__/shared/components/SubmissionManagement/__snapshots__/SubmissionsTable.jsx.snap
+++ b/__tests__/shared/components/SubmissionManagement/__snapshots__/SubmissionsTable.jsx.snap
@@ -25,6 +25,7 @@ exports[`Matches shallow shapshot 1`] = `
     </thead>
     <tbody>
       <Submission
+        allowDelete={false}
         challenge={
           Object {
             "id": "test-challenge",

--- a/__tests__/shared/utils/challenge-detail/submission-limit.test.js
+++ b/__tests__/shared/utils/challenge-detail/submission-limit.test.js
@@ -1,5 +1,6 @@
 /* eslint-env jest */
 import {
+  belongsToActiveSubmissionPhase,
   getActiveSubmissionCount,
   getActiveSubmissionType,
   getSubmissionLimit,
@@ -129,6 +130,63 @@ describe('active submission phase limits', () => {
       submissions,
       phases,
     )).toBe(false);
+  });
+});
+
+describe('belongsToActiveSubmissionPhase', () => {
+  test('allows deleting a checkpoint submission while the checkpoint phase is open', () => {
+    const phases = [
+      { isOpen: true, name: 'Checkpoint Submission' },
+      { isOpen: false, name: 'Submission' },
+    ];
+
+    expect(belongsToActiveSubmissionPhase(
+      { id: 'checkpoint-submission', type: 'CHECKPOINT_SUBMISSION' },
+      phases,
+    )).toBe(true);
+    expect(belongsToActiveSubmissionPhase(
+      { id: 'legacy-checkpoint', submissionType: 'checkpoint' },
+      phases,
+    )).toBe(true);
+  });
+
+  test('blocks deleting a checkpoint submission once the submission phase opens', () => {
+    const phases = [
+      { isOpen: false, name: 'Checkpoint Submission' },
+      { isOpen: true, name: 'Submission' },
+    ];
+
+    expect(belongsToActiveSubmissionPhase(
+      { id: 'checkpoint-submission', type: 'CHECKPOINT_SUBMISSION' },
+      phases,
+    )).toBe(false);
+    expect(belongsToActiveSubmissionPhase(
+      { id: 'contest-submission', type: 'CONTEST_SUBMISSION' },
+      phases,
+    )).toBe(true);
+  });
+
+  test('blocks deleting anything once every submission phase is closed', () => {
+    const phases = [
+      { isOpen: false, name: 'Checkpoint Submission' },
+      { isOpen: false, name: 'Submission' },
+      { isOpen: true, name: 'Checkpoint Review' },
+      { isOpen: true, name: 'Review' },
+    ];
+
+    expect(belongsToActiveSubmissionPhase(
+      { id: 'checkpoint-submission', type: 'CHECKPOINT_SUBMISSION' },
+      phases,
+    )).toBe(false);
+    expect(belongsToActiveSubmissionPhase(
+      { id: 'contest-submission', type: 'CONTEST_SUBMISSION' },
+      phases,
+    )).toBe(false);
+  });
+
+  test('resolves to false for missing submissions or phases', () => {
+    expect(belongsToActiveSubmissionPhase(null, [{ isOpen: true, name: 'Submission' }])).toBe(false);
+    expect(belongsToActiveSubmissionPhase({ type: 'CONTEST_SUBMISSION' }, undefined)).toBe(false);
   });
 });
 

--- a/src/shared/components/SubmissionManagement/SubmissionManagement/index.jsx
+++ b/src/shared/components/SubmissionManagement/SubmissionManagement/index.jsx
@@ -40,7 +40,6 @@ export default function SubmissionManagement(props) {
     onShowDetails,
     challengeUrl,
     onlineReviewUrl,
-    submissionPhaseStartDate,
     onDownloadArtifacts,
     getSubmissionArtifacts,
     getSubmissionScores,
@@ -191,7 +190,6 @@ export default function SubmissionManagement(props) {
              showDetails={showDetails}
              track={trackName}
              status={challenge.status}
-             submissionPhaseStartDate={submissionPhaseStartDate}
              {...componentConfig}
            />
            )
@@ -251,5 +249,4 @@ SubmissionManagement.propTypes = {
   submissionLimitCheckPending: PT.bool,
   loadingSubmissions: PT.bool,
   challengeUrl: PT.string,
-  submissionPhaseStartDate: PT.string.isRequired,
 };

--- a/src/shared/components/SubmissionManagement/SubmissionsTable/index.jsx
+++ b/src/shared/components/SubmissionManagement/SubmissionsTable/index.jsx
@@ -18,8 +18,8 @@ import _ from 'lodash';
 import React, { useCallback, useState } from 'react';
 import PT from 'prop-types';
 import shortid from 'shortid';
-import moment from 'moment';
 import { COMPETITION_TRACKS } from 'utils/tc';
+import { belongsToActiveSubmissionPhase } from 'utils/challenge-detail/submission-limit';
 import ScreeningDetails from '../ScreeningDetails';
 import DownloadArtifactsModal from '../DownloadArtifactsModal';
 import Submission from '../Submission';
@@ -45,7 +45,6 @@ export default function SubmissionsTable(props) {
     onDownload,
     onShowDetails,
     status,
-    submissionPhaseStartDate,
     onDownloadArtifacts,
     getSubmissionArtifacts,
     getSubmissionScores,
@@ -72,9 +71,6 @@ export default function SubmissionsTable(props) {
     ));
   } else {
     submissionObjects.forEach((subObject) => {
-      // submissionPhaseStartDate will be the start date of
-      // the current submission/checkpoint or empty string if any other phase
-
       const TERMINAL_STATUSES = [
         'COMPLETED',
         'FAILURE',
@@ -93,8 +89,8 @@ export default function SubmissionsTable(props) {
         ? true
         : workflowRunsForSubmission.every(run => TERMINAL_STATUSES.includes(run.status));
 
-      const allowDelete = submissionPhaseStartDate
-        && moment(subObject.submissionDate).isAfter(submissionPhaseStartDate);
+      // Submissions can only be removed while the phase that created them is still open.
+      const allowDelete = belongsToActiveSubmissionPhase(subObject, challenge.phases);
 
 
       const submission = (
@@ -233,6 +229,5 @@ SubmissionsTable.propTypes = {
   onDownloadArtifacts: PT.func,
   getSubmissionArtifacts: PT.func,
   status: PT.string.isRequired,
-  submissionPhaseStartDate: PT.string.isRequired,
   getSubmissionScores: PT.func,
 };

--- a/src/shared/containers/SubmissionManagement/index.jsx
+++ b/src/shared/containers/SubmissionManagement/index.jsx
@@ -483,7 +483,6 @@ export class SubmissionManagementPageContainer extends React.Component {
       challengesUrl,
       deleting,
       loadingSubmissionsForChallengeId,
-      submissionPhaseStartDate,
       isLoadingChallenge,
       onCancelSubmissionDelete,
       onShowDetails,
@@ -562,7 +561,6 @@ export class SubmissionManagementPageContainer extends React.Component {
               submissionLimitCheckPending={submissionLimitCheckPending}
               showDetails={showDetails}
               submissionWorkflowRuns={submissionWorkflowRuns}
-              submissionPhaseStartDate={submissionPhaseStartDate}
               {...smConfig}
             />
             )}
@@ -672,7 +670,6 @@ SubmissionManagementPageContainer.propTypes = {
   toBeDeletedId: PT.string,
   deletionSucceed: PT.bool,
   onSubmissionDeleteConfirmed: PT.func.isRequired,
-  submissionPhaseStartDate: PT.string.isRequired,
 };
 
 function mapStateToProps(state, props) {
@@ -681,9 +678,6 @@ function mapStateToProps(state, props) {
   let { mySubmissions } = state.challenge;
   mySubmissions = challengeId === mySubmissions.challengeId
     ? mySubmissions.v2 : null;
-
-  const allPhases = state.challenge.details.phases || [];
-  const submissionPhase = allPhases.find(phase => ['Submission', 'Checkpoint Submission'].includes(phase.name) && phase.isOpen) || {};
 
   return {
     challengeId: String(challengeId),
@@ -697,8 +691,6 @@ function mapStateToProps(state, props) {
     loadingSubmissionsForChallengeId:
       state.challenge.loadingSubmissionsForChallengeId || '',
     mySubmissions,
-
-    submissionPhaseStartDate: submissionPhase.actualStartDate || submissionPhase.scheduledStartDate || '',
 
     showDetails: state.page.submissionManagement.showDetails,
 

--- a/src/shared/utils/challenge-detail/submission-limit.js
+++ b/src/shared/utils/challenge-detail/submission-limit.js
@@ -2,6 +2,7 @@ const SUBMISSION_LIMIT_METADATA_NAME = 'submissionLimit';
 const CHECKPOINT_SUBMISSION_TYPE = 'CHECKPOINT_SUBMISSION';
 const CONTEST_SUBMISSION_TYPE = 'CONTEST_SUBMISSION';
 const FINAL_FIX_SUBMISSION_TYPE = 'STUDIO_FINAL_FIX_SUBMISSION';
+const SUBMISSION_PHASE_NAMES = ['Checkpoint Submission', 'Submission'];
 
 /**
  * Converts a metadata value to a positive integer submission limit.
@@ -162,6 +163,33 @@ function normalizeSubmissionType(value) {
   }
 
   return normalizedValue;
+}
+
+/**
+ * Checks whether a submission was created by the currently open submission phase.
+ *
+ * Submitters may only remove a submission while the phase that produced it is still open. A
+ * checkpoint submission therefore stops being deletable as soon as the Checkpoint Submission
+ * phase ends, even though the Submission phase opens right after it, and nothing is deletable
+ * once every submission phase is closed (screening, review, appeals, ...).
+ *
+ * @param {Object} submission Member submission, using the V6 `type` or legacy `submissionType`.
+ * @param {Array<Object>} phases Challenge phases.
+ * @return {Boolean} Whether the submission belongs to the currently open submission phase.
+ * @throws Does not throw; missing submissions or phases resolve to false.
+ */
+export function belongsToActiveSubmissionPhase(submission, phases) {
+  const challengePhases = Array.isArray(phases) ? phases : [];
+  const hasOpenSubmissionPhase = challengePhases.some(phase => (
+    phase && phase.isOpen && SUBMISSION_PHASE_NAMES.includes(phase.name)
+  ));
+
+  if (!submission || !hasOpenSubmissionPhase) {
+    return false;
+  }
+
+  return normalizeSubmissionType(submission.type || submission.submissionType)
+    === getActiveSubmissionType(challengePhases);
 }
 
 /**


### PR DESCRIPTION
## What was broken

In Design challenges the submitter could still delete a submission after the phase that created it had ended. A checkpoint submission stayed deletable for the whole Submission phase, so it could be removed after it had already passed Checkpoint Screening and been scored in Checkpoint Review — exactly the scenario in the PM-5961 recording.

Expected behaviour: a submission can only be deleted while the phase that produced it is open (Checkpoint Submission for checkpoint submissions, Submission for contest submissions), and nothing is deletable once every submission phase is closed.

## Root cause

`SubmissionsTable` computed the delete permission from a single `submissionPhaseStartDate` prop, which the container derived as the start date of *any* open `Submission` or `Checkpoint Submission` phase:

```js
const allowDelete = submissionPhaseStartDate
  && moment(subObject.submissionDate).isAfter(submissionPhaseStartDate);
```

Two problems:

1. `submissionDate` is not a field on member submissions (they expose `created`), so `moment(undefined)` resolved to "now". The expression collapsed to "now is after the open phase start", i.e. always true whenever any submission phase was open.
2. Even with the right date field, the check never looked at the submission's own type, so a checkpoint submission was treated as belonging to the open Submission phase.

## What was changed

- Added `belongsToActiveSubmissionPhase()` to `utils/challenge-detail/submission-limit`. It reuses the existing `getActiveSubmissionType()` phase precedence (already used for submission limits and for typing new uploads) to decide whether a submission was created by the currently open submission phase, and returns `false` when no submission phase is open at all. Both the V6 `type` and the legacy `submissionType` fields are supported.
- `SubmissionsTable` now derives `allowDelete` from that helper against `challenge.phases`, so:
  - checkpoint submissions are deletable only during Checkpoint Submission,
  - contest submissions are deletable only during Submission,
  - nothing is deletable during screening / review / appeals / after completion.
- Removed the now-unused `submissionPhaseStartDate` prop from the submission management container and components (it existed only to feed the old check).

The existing "You can delete this submission only after the review is complete" workflow-run gating and the `COMPLETED` / Design-track conditions on the delete button are unchanged.

## Any added/updated tests

`__tests__/shared/utils/challenge-detail/submission-limit.test.js` — new `belongsToActiveSubmissionPhase` suite:

- allows deleting a checkpoint submission (current and legacy type fields) while the Checkpoint Submission phase is open
- blocks deleting a checkpoint submission once the Submission phase opens, while still allowing contest submissions
- blocks deleting anything once every submission phase is closed (Checkpoint Review / Review open)
- resolves to `false` for missing submissions or missing phases

Also updated the `SubmissionsTable` shallow snapshot, which now records the boolean `allowDelete={false}` prop (previously `undefined`, and therefore omitted, because the test fixture supplies no `submissionPhaseStartDate`).

Validation run: `npm run lint` (clean), `npm run jest` — 380 passed, 141 snapshots passed, 0 failures; `npm run build` succeeds.

The companion API enforcement is in topcoder-platform/review-api-v6 PM-5961.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
