### PR TITLE
Increase Payload compatibility timeout default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you need any operations related to currency conversions, pay attention to the
     -   `CONTENTFUL_PREVIEW_API_KEY`
     -   `CONTENTFUL_CDN_API_HOST`
     -   `CONTENTFUL_PREVIEW_API_HOST`
-    -   `CONTENTFUL_PAYLOAD_REQUEST_TIMEOUT_MS` (optional; defaults to 10000)
+    -   `CONTENTFUL_PAYLOAD_REQUEST_TIMEOUT_MS` (optional; defaults to 30000)
 
     See [Payload CMS compatibility environment setup](docs/contentful/environment-setup.md)
     for supported spaces, S3 asset configuration, and article-vote write-through.

--- a/__tests__/server/contentful.js
+++ b/__tests__/server/contentful.js
@@ -145,7 +145,7 @@ describe('server/services/contentful Payload compatibility client', () => {
   test.each([
     [500, 1000],
     [60000, 30000],
-    ['invalid', 10000],
+    ['invalid', 30000],
   ])('keeps configured request timeout %p within safe bounds', async (configured, expected) => {
     const originalTimeout = config.CONTENTFUL.PAYLOAD_REQUEST_TIMEOUT_MS;
     config.CONTENTFUL.PAYLOAD_REQUEST_TIMEOUT_MS = configured;

--- a/config/default.js
+++ b/config/default.js
@@ -56,7 +56,7 @@ module.exports = {
     DEFAULT_ENVIRONMENT: 'master',
     CHANGELOG_ID: '5ULnHeUIuYAyLhNO97zAqy',
     /* Per-request timeout for Payload compatibility reads and writes. */
-    PAYLOAD_REQUEST_TIMEOUT_MS: 10 * 1000,
+    PAYLOAD_REQUEST_TIMEOUT_MS: 30 * 1000,
   },
 
   /**

--- a/docs/contentful/environment-setup.md
+++ b/docs/contentful/environment-setup.md
@@ -45,8 +45,8 @@ export PAYLOAD_CMS_URL="https://cms.topcoder-dev.com"
 export PAYLOAD_CMS_ASSET_URL="https://assets.topcoder-dev.com"
 export CONTENTFUL_PAYLOAD_VOTE_API_URL="https://cms.topcoder-dev.com/contentful-management/votes"
 export CONTENTFUL_PAYLOAD_MANAGEMENT_API_KEY="<PAYLOAD_SERVICE_CREDENTIAL>"
-# Optional; defaults to 10000 and is clamped to the 1000-30000 ms range.
-export CONTENTFUL_PAYLOAD_REQUEST_TIMEOUT_MS="10000"
+# Optional; defaults to 30000 and is clamped to the 1000-30000 ms range.
+export CONTENTFUL_PAYLOAD_REQUEST_TIMEOUT_MS="30000"
 ```
 
 The vote URL and credential are required for article voting. There is no

--- a/src/server/services/contentful.js
+++ b/src/server/services/contentful.js
@@ -21,7 +21,7 @@ import { assertNoRetiredCmsUrls } from './cms-urls';
 
 const cmsHttpsAgent = new https.Agent({ keepAlive: true });
 const MAX_FETCH_RETRIES = 5;
-const DEFAULT_REQUEST_TIMEOUT_MS = 10 * 1000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30 * 1000;
 const MIN_REQUEST_TIMEOUT_MS = 1000;
 const MAX_REQUEST_TIMEOUT_MS = 30 * 1000;
 


### PR DESCRIPTION
Summary:
- raise the default Payload compatibility request timeout from 10 seconds to 30 seconds
- retain the 1,000-30,000 ms clamp and CONTENTFUL_PAYLOAD_REQUEST_TIMEOUT_MS override
- update timeout documentation and invalid-value fallback coverage

Validation:
- focused CMS tests: 44 passed
- npm run lint
- npm run verify:no-retired-cms-targets
- npm run build