### PR TITLE
Fix Live Preview for unpublished Thrive articles

### DIFF
--- a/__tests__/shared/routes/Topcoder/ThriveArticleRoute.jsx
+++ b/__tests__/shared/routes/Topcoder/ThriveArticleRoute.jsx
@@ -1,0 +1,29 @@
+import ContentfulLoader from 'containers/ContentfulLoader';
+import LivePreview from 'components/Contentful/Article/LivePreview';
+import LoadingIndicator from 'components/LoadingIndicator';
+import ThriveArticleRoute from 'routes/Topcoder/ThriveArticleRoute';
+
+const routeProps = search => ({
+  location: { search },
+  match: { params: { articleTitle: 'brand-new-article' } },
+});
+
+describe('Thrive article route', () => {
+  test('uses the authenticated graph before querying an unpublished slug', () => {
+    const output = ThriveArticleRoute(routeProps('?payloadLivePreview=1'));
+
+    expect(output.type).toBe(LivePreview);
+    expect(output.props.children.type).toBe(LoadingIndicator);
+  });
+
+  test('keeps ordinary routes on the published compatibility query', () => {
+    const output = ThriveArticleRoute(routeProps(''));
+
+    expect(output.type).toBe(ContentfulLoader);
+    expect(output.props.entryQueries).toEqual({
+      content_type: 'article',
+      'fields.slug': 'brand-new-article',
+    });
+    expect(output.props.spaceName).toBe('EDU');
+  });
+});

--- a/src/shared/routes/Topcoder/Routes.jsx
+++ b/src/shared/routes/Topcoder/Routes.jsx
@@ -5,7 +5,6 @@
  * content of the route, or the HTTP 404 page.
  */
 
-import _ from 'lodash';
 import ChallengeDetails from 'routes/ChallengeDetails';
 import ContentfulRoute from 'components/Contentful/Route';
 import TermsDetail from 'routes/TermsDetail';
@@ -17,10 +16,7 @@ import ReviewOpportunityDetails from 'routes/ReviewOpportunityDetails';
 import Submission from 'routes/Submission';
 import SubmissionManagement from 'routes/SubmissionManagement';
 import { Route, Switch, Redirect } from 'react-router-dom';
-import { config, isomorphy } from 'topcoder-react-utils';
-import ContentfulLoader from 'containers/ContentfulLoader';
-import LoadingIndicator from 'components/LoadingIndicator';
-import Article from 'components/Contentful/Article';
+import { config } from 'topcoder-react-utils';
 import Viewport from 'components/Contentful/Viewport';
 
 import EDUHome from '../EDUHome';
@@ -33,6 +29,7 @@ import Notifications from './Notifications';
 import HallOfFame from '../HallOfFame';
 import ProfileBadges from '../ProfileBadges';
 import Scoreboard from '../tco/scoreboard';
+import ThriveArticleRoute from './ThriveArticleRoute';
 
 import './styles.scss';
 
@@ -110,75 +107,7 @@ export default function Topcoder() {
           path={`${config.TC_EDU_BASE_PATH}${config.TC_EDU_SEARCH_PATH}`}
         />
         <Route
-          component={(p) => {
-            const { articleTitle } = p.match.params;
-            return (
-              <ContentfulLoader
-                entryQueries={{
-                  content_type: 'article',
-                  'fields.slug': articleTitle,
-                }}
-                spaceName="EDU"
-                render={(data) => {
-                  if (_.isEmpty(data.entries.items)) {
-                    // try search by title match
-                    // this legacy support should be deprecated when all
-                    // Thrive links switched to hypens, someday
-                    return (
-                      <ContentfulLoader
-                        entryQueries={{
-                          content_type: 'article',
-                          'fields.title[match]': articleTitle,
-                        }}
-                        spaceName="EDU"
-                        render={(dataTitle) => {
-                          if (_.isEmpty(dataTitle.entries.items)) return <Error404 />;
-                          let id = dataTitle.entries.matches[0].items[0];
-                          if (dataTitle.entries.matches[0].total !== 1) {
-                            // more than 1 match. we need to try find best
-                            const mId = _.findKey(
-                              dataTitle.entries.items,
-                              // eslint-disable-next-line max-len
-                              o => o.fields.title.toLocaleLowerCase() === articleTitle.toLocaleLowerCase(),
-                            );
-                            id = mId || id;
-                          }
-                          const {
-                            externalArticle,
-                            contentUrl,
-                          } = dataTitle.entries.items[id].fields;
-                          if (externalArticle && contentUrl && isomorphy.isClientSide()) {
-                            window.location.href = contentUrl;
-                            return null;
-                          }
-                          return (
-                            <Article
-                              id={id}
-                              spaceName="EDU"
-                            />
-                          );
-                        }}
-                        renderPlaceholder={LoadingIndicator}
-                      />
-                    );
-                  }
-                  const id = data.entries.matches[0].items[0];
-                  const { externalArticle, contentUrl } = data.entries.items[id].fields;
-                  if (externalArticle && contentUrl && isomorphy.isClientSide()) {
-                    window.location.href = contentUrl;
-                    return null;
-                  }
-                  return (
-                    <Article
-                      id={id}
-                      spaceName="EDU"
-                    />
-                  );
-                }}
-                renderPlaceholder={LoadingIndicator}
-              />
-            );
-          }}
+          component={ThriveArticleRoute}
           exact
           path={`${config.TC_EDU_BASE_PATH}${config.TC_EDU_ARTICLES_PATH}/:articleTitle`}
         />

--- a/src/shared/routes/Topcoder/ThriveArticleRoute.jsx
+++ b/src/shared/routes/Topcoder/ThriveArticleRoute.jsx
@@ -1,0 +1,83 @@
+/** Loads a public Thrive article or its authenticated Payload Live Preview graph. */
+import _ from 'lodash';
+import Article from 'components/Contentful/Article';
+import LivePreview, {
+  isThriveLivePreview,
+} from 'components/Contentful/Article/LivePreview';
+import Error404 from 'components/Error404';
+import LoadingIndicator from 'components/LoadingIndicator';
+import ContentfulLoader from 'containers/ContentfulLoader';
+import PT from 'prop-types';
+import React from 'react';
+import { isomorphy } from 'topcoder-react-utils';
+
+/** Route implementation shared by server rendering and client navigation. */
+export default function ThriveArticleRoute(props) {
+  const { location, match } = props;
+  if (isThriveLivePreview(location.search)) {
+    return (
+      <LivePreview>
+        <LoadingIndicator />
+      </LivePreview>
+    );
+  }
+
+  const { articleTitle } = match.params;
+  return (
+    <ContentfulLoader
+      entryQueries={{
+        content_type: 'article',
+        'fields.slug': articleTitle,
+      }}
+      spaceName="EDU"
+      render={(data) => {
+        if (_.isEmpty(data.entries.items)) {
+          // Legacy articles used their title as the route before slugs were introduced.
+          return (
+            <ContentfulLoader
+              entryQueries={{
+                content_type: 'article',
+                'fields.title[match]': articleTitle,
+              }}
+              spaceName="EDU"
+              render={(dataTitle) => {
+                if (_.isEmpty(dataTitle.entries.items)) return <Error404 />;
+                let id = dataTitle.entries.matches[0].items[0];
+                if (dataTitle.entries.matches[0].total !== 1) {
+                  const matchedId = _.findKey(
+                    dataTitle.entries.items,
+                    article => article.fields.title.toLocaleLowerCase()
+                      === articleTitle.toLocaleLowerCase(),
+                  );
+                  id = matchedId || id;
+                }
+                const { externalArticle, contentUrl } = dataTitle.entries.items[id].fields;
+                if (externalArticle && contentUrl && isomorphy.isClientSide()) {
+                  window.location.href = contentUrl;
+                  return null;
+                }
+                return <Article id={id} spaceName="EDU" />;
+              }}
+              renderPlaceholder={LoadingIndicator}
+            />
+          );
+        }
+        const id = data.entries.matches[0].items[0];
+        const { externalArticle, contentUrl } = data.entries.items[id].fields;
+        if (externalArticle && contentUrl && isomorphy.isClientSide()) {
+          window.location.href = contentUrl;
+          return null;
+        }
+        return <Article id={id} spaceName="EDU" />;
+      }}
+      renderPlaceholder={LoadingIndicator}
+    />
+  );
+}
+
+ThriveArticleRoute.propTypes = {
+  location: PT.shape({ search: PT.string }).isRequired,
+  match: PT.shape({
+    params: PT.shape({ articleTitle: PT.string.isRequired }).isRequired,
+  }).isRequired,
+};


### PR DESCRIPTION
## Summary

- route explicitly marked Thrive previews into the authenticated Payload Live Preview bridge before any published slug lookup
- keep the existing slug lookup, legacy title fallback, and external-article redirects unchanged for normal public visits
- add focused coverage for unpublished preview bootstrap and ordinary published routing
- make no configuration, infrastructure, or SecureString changes

## Validation

- npm run lint:js
- focused Jest suites for the Live Preview bridge and Thrive article route (5 tests)
- production Webpack build
- npm run verify:no-retired-cms-targets